### PR TITLE
style: run prettier on entire code base

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
+  "printWidth": 100,
   "singleQuote": true
 }

--- a/final/src/App.js
+++ b/final/src/App.js
@@ -12,34 +12,47 @@ import TimesheetsCreate from './components/timesheets/TimesheetsCreate';
 import TimeunitsCreate from './components/timeunits/TimeunitsCreate';
 import TimeunitsDetail from './components/timeunits/TimeunitsDetail';
 import Navigation from './components/nav/Navigation';
-import {BrowserRouter, Route, Switch, Redirect} from 'react-router-dom';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 
 class App extends Component {
   render() {
     return (
       <BrowserRouter>
         <div className="App">
-          <Navigation/>
-            <Switch>
-              <Route exact path="/projects" component={Projects}/>
-              <Route path='/projects/detail/:_id' component={ProjectsDetail} />
-              <Route path='/projects/create' component={ProjectsCreate} />
+          <Navigation />
+          <Switch>
+            <Route exact path="/projects" component={Projects} />
+            <Route path="/projects/detail/:_id" component={ProjectsDetail} />
+            <Route path="/projects/create" component={ProjectsCreate} />
 
-              <Route exact path="/employees" component={Employees}/>
-              <Route path='/employees/detail/:_id' component={EmployeesDetail} />
-              <Route path='/employees/create' component={EmployeesCreate} />
+            <Route exact path="/employees" component={Employees} />
+            <Route path="/employees/detail/:_id" component={EmployeesDetail} />
+            <Route path="/employees/create" component={EmployeesCreate} />
 
-              <Route exact path="/employees/:user_id/timesheets" component={Timesheets}/>
-              <Route exact path='/employees/:user_id/timesheets/detail/:_id' component={TimesheetsDetail} />
+            <Route
+              exact
+              path="/employees/:user_id/timesheets"
+              component={Timesheets}
+            />
+            <Route
+              exact
+              path="/employees/:user_id/timesheets/detail/:_id"
+              component={TimesheetsDetail}
+            />
 
-              <Route path='/timesheets/create' component={TimesheetsCreate} />
+            <Route path="/timesheets/create" component={TimesheetsCreate} />
 
-              <Route path='/employees/:user_id/timesheets/detail/:timesheet_id/timeunits/create' component={TimeunitsCreate} />
-              <Route path='/employees/:user_id/timesheets/detail/:timesheet_id/timeunits/detail/:_id' component={TimeunitsDetail} />
+            <Route
+              path="/employees/:user_id/timesheets/detail/:timesheet_id/timeunits/create"
+              component={TimeunitsCreate}
+            />
+            <Route
+              path="/employees/:user_id/timesheets/detail/:timesheet_id/timeunits/detail/:_id"
+              component={TimeunitsDetail}
+            />
 
-              <Redirect to="/employees"/>
-            </Switch>
-
+            <Redirect to="/employees" />
+          </Switch>
         </div>
       </BrowserRouter>
     );

--- a/final/src/App.js
+++ b/final/src/App.js
@@ -29,11 +29,7 @@ class App extends Component {
             <Route path="/employees/detail/:_id" component={EmployeesDetail} />
             <Route path="/employees/create" component={EmployeesCreate} />
 
-            <Route
-              exact
-              path="/employees/:user_id/timesheets"
-              component={Timesheets}
-            />
+            <Route exact path="/employees/:user_id/timesheets" component={Timesheets} />
             <Route
               exact
               path="/employees/:user_id/timesheets/detail/:_id"

--- a/final/src/App.test.js
+++ b/final/src/App.test.js
@@ -11,9 +11,6 @@ describe('App Component', () => {
   it('renders with our expected text', () => {
     const result = shallow(<App />);
 
-    expect(result.find('Route').at(1)).toHaveProp(
-      'path',
-      '/projects/detail/:_id'
-    );
+    expect(result.find('Route').at(1)).toHaveProp('path', '/projects/detail/:_id');
   });
 });

--- a/final/src/App.test.js
+++ b/final/src/App.test.js
@@ -9,10 +9,11 @@ describe('App Component', () => {
   });
 
   it('renders with our expected text', () => {
-
     const result = shallow(<App />);
 
-    expect(result.find('Route').at(1)).toHaveProp('path', '/projects/detail/:_id');
-
+    expect(result.find('Route').at(1)).toHaveProp(
+      'path',
+      '/projects/detail/:_id'
+    );
   });
 });

--- a/final/src/actions/EmployeeActionCreator.js
+++ b/final/src/actions/EmployeeActionCreator.js
@@ -1,35 +1,33 @@
 import * as EmployeeActionTypes from './EmployeeActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/users';
 
-const url = (employeeId) => {
-
+const url = employeeId => {
   let url = apiUrl;
   if (employeeId) {
     url += '/' + employeeId;
   }
 
   return url;
-}
+};
 
-export const list = (employees) => {
+export const list = employees => {
   return {
     type: EmployeeActionTypes.LIST,
     employees: employees
-  }
-}
+  };
+};
 
-export const get = (employee) => {
+export const get = employee => {
   return {
     type: EmployeeActionTypes.GET,
     employee: employee
-  }
-}
+  };
+};
 
 export const listEmployees = () => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -39,10 +37,10 @@ export const listEmployees = () => {
         console.log('Error attempting to retrieve employees.', error);
       });
   };
-}
+};
 
-export const getEmployee = (id) => {
-  return (dispatch) => {
+export const getEmployee = id => {
+  return dispatch => {
     return Axios.get(url(id))
       .then(res => {
         dispatch(get(res.data));
@@ -51,11 +49,11 @@ export const getEmployee = (id) => {
       .catch(error => {
         console.log('There was an error getting the employee');
       });
-  }
-}
+  };
+};
 
-export const updateEmployee = (employee) => {
-  return (dispatch) => {
+export const updateEmployee = employee => {
+  return dispatch => {
     return Axios.put(url(employee._id), employee)
       .then(res => {
         dispatch(get(res.data));
@@ -65,11 +63,11 @@ export const updateEmployee = (employee) => {
       .catch(error => {
         console.log('There was an error updating employee.');
       });
-  }
-}
+  };
+};
 
-export const removeEmployee = (employee) => {
-  return (dispatch) => {
+export const removeEmployee = employee => {
+  return dispatch => {
     employee.deleted = true;
 
     return Axios.put(url(employee._id), employee)
@@ -81,36 +79,35 @@ export const removeEmployee = (employee) => {
       .catch(error => {
         console.log('Error attempting to delete employee.');
       });
-  }
-}
+  };
+};
 
-export const restoreEmployee = (employee) => {
-  return (dispatch) => {
+export const restoreEmployee = employee => {
+  return dispatch => {
     employee.deleted = false;
 
     return Axios.put(url(employee._id), employee)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Employee : ' + res.data.name + ', was restored.');
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore employee.');
       });
-  }
-}
+  };
+};
 
-export const createEmployee = (employee) => {
-  return (dispatch) => {
+export const createEmployee = employee => {
+  return dispatch => {
     return Axios.post(url(), employee)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Employee : ' + res.data.name + ', created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating employee.');
       });
-  }
-}
-
+  };
+};

--- a/final/src/actions/EmployeeActionCreator.test.js
+++ b/final/src/actions/EmployeeActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './EmployeeActionCreator'
-import * as types from './EmployeeActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './EmployeeActionCreator';
+import * as types from './EmployeeActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        employees: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      employees: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        employee: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      employee: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching employees has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['employee1', 'employee2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, employees: ['employee1', 'employee2']}
-    ]
-    const store = mockStore({employees: []})
+      { type: types.LIST, employees: ['employee1', 'employee2'] }
+    ];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.listEmployees())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listEmployees()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single employee', () => {
     moxios.stubRequest('/api/users/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
-
-    return store.dispatch(actions.getEmployee(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getEmployee(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a employee', () => {
     moxios.stubRequest('/api/users/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.updateEmployee({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateEmployee({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a employee', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.removeEmployee({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeEmployee({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a employee', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.restoreEmployee({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreEmployee({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/final/src/actions/EmployeeActionCreator.test.js
+++ b/final/src/actions/EmployeeActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['employee1', 'employee2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, employees: ['employee1', 'employee2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, employees: ['employee1', 'employee2'] }];
     const store = mockStore({ employees: [] });
 
     return store.dispatch(actions.listEmployees()).then(() => {

--- a/final/src/actions/EmployeeActionTypes.js
+++ b/final/src/actions/EmployeeActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_EMPLOYEES";
-export const GET = "GET_EMPLOYEE";
+export const LIST = 'LIST_EMPLOYEES';
+export const GET = 'GET_EMPLOYEE';

--- a/final/src/actions/ProjectActionCreator.js
+++ b/final/src/actions/ProjectActionCreator.js
@@ -1,21 +1,19 @@
 import * as ProjectActionTypes from './ProjectActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/projects';
 
-const url = (projectId) => {
-
+const url = projectId => {
   let url = apiUrl;
   if (projectId) {
     url += '/' + projectId;
   }
 
   return url;
-}
+};
 
 export const listProjects = () => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -25,10 +23,10 @@ export const listProjects = () => {
         console.log('Error attempting to retrieve projects.', error);
       });
   };
-}
+};
 
-export const getProject = (id) => {
-  return (dispatch) => {
+export const getProject = id => {
+  return dispatch => {
     return Axios.get(url(id))
       .then(res => {
         dispatch(get(res.data));
@@ -37,11 +35,11 @@ export const getProject = (id) => {
       .catch(error => {
         console.log('There was an error getting the project');
       });
-  }
-}
+  };
+};
 
-export const updateProject = (project) => {
-  return (dispatch) => {
+export const updateProject = project => {
+  return dispatch => {
     return Axios.put(url(project._id), project)
       .then(res => {
         dispatch(get(res.data));
@@ -51,11 +49,11 @@ export const updateProject = (project) => {
       .catch(error => {
         console.log('There was an error updating project.');
       });
-  }
-}
+  };
+};
 
-export const removeProject = (project) => {
-  return (dispatch) => {
+export const removeProject = project => {
+  return dispatch => {
     project.deleted = true;
 
     return Axios.put(url(project._id), project)
@@ -67,49 +65,49 @@ export const removeProject = (project) => {
       .catch(error => {
         console.log('Error attempting to delete project.');
       });
-  }
-}
+  };
+};
 
-export const restoreProject = (project) => {
-  return (dispatch) => {
+export const restoreProject = project => {
+  return dispatch => {
     project.deleted = false;
 
     return Axios.put(url(project._id), project)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Project : ' + res.data.name + ', was restored.');
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore project.');
       });
-  }
-}
+  };
+};
 
-export const createProject = (project) => {
-  return (dispatch) => {
+export const createProject = project => {
+  return dispatch => {
     return Axios.post(url(), project)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Project : ' + res.data.name + ', created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating project.');
       });
-  }
-}
+  };
+};
 
-export const list = (projects) => {
+export const list = projects => {
   return {
     type: ProjectActionTypes.LIST,
     projects: projects
-  }
-}
+  };
+};
 
-export const get = (project) => {
+export const get = project => {
   return {
     type: ProjectActionTypes.GET,
     project: project
-  }
-}
+  };
+};

--- a/final/src/actions/ProjectActionCreator.test.js
+++ b/final/src/actions/ProjectActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './ProjectActionCreator'
-import * as types from './ProjectActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './ProjectActionCreator';
+import * as types from './ProjectActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        projects: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      projects: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        project: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      project: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching projects has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['project1', 'project2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, projects: ['project1', 'project2']}
-    ]
-    const store = mockStore({projects: []})
+      { type: types.LIST, projects: ['project1', 'project2'] }
+    ];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.listProjects())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listProjects()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single project', () => {
     moxios.stubRequest('/api/projects/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'project1'
     });
 
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
-
-    return store.dispatch(actions.getProject(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getProject(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a project', () => {
     moxios.stubRequest('/api/projects/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.updateProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a project', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.removeProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a project', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.restoreProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/final/src/actions/ProjectActionCreator.test.js
+++ b/final/src/actions/ProjectActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['project1', 'project2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, projects: ['project1', 'project2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, projects: ['project1', 'project2'] }];
     const store = mockStore({ projects: [] });
 
     return store.dispatch(actions.listProjects()).then(() => {

--- a/final/src/actions/ProjectActionTypes.js
+++ b/final/src/actions/ProjectActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_PROJECTS";
-export const GET = "GET_PROJECT";
+export const LIST = 'LIST_PROJECTS';
+export const GET = 'GET_PROJECT';

--- a/final/src/actions/TimesheetActionCreator.js
+++ b/final/src/actions/TimesheetActionCreator.js
@@ -1,16 +1,16 @@
 import * as TimesheetActionTypes from './TimesheetActionTypes';
 import Axios from 'axios';
 
-const url = (timesheetId, userId='all') => {
+const url = (timesheetId, userId = 'all') => {
   const url = `/api/users/${userId}/timesheets`;
   if (timesheetId) {
     return url + '/' + timesheetId;
   }
   return url;
-}
+};
 
 export const listTimesheets = () => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -20,10 +20,10 @@ export const listTimesheets = () => {
         console.log('Error attempting to retrieve timesheets.');
       });
   };
-}
+};
 
 export const getTimesheet = (id, userId) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url(id, userId))
       .then(res => {
         dispatch(get(res.data));
@@ -32,11 +32,11 @@ export const getTimesheet = (id, userId) => {
       .catch(error => {
         console.log('There was an error getting the timesheet');
       });
-  }
-}
+  };
+};
 
-export const updateTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const updateTimesheet = timesheet => {
+  return dispatch => {
     return Axios.put(url(timesheet._id), timesheet)
       .then(res => {
         dispatch(get(res.data));
@@ -46,11 +46,11 @@ export const updateTimesheet = (timesheet) => {
       .catch(error => {
         console.log('There was an error updating timesheet.');
       });
-  }
-}
+  };
+};
 
-export const removeTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const removeTimesheet = timesheet => {
+  return dispatch => {
     timesheet.deleted = true;
 
     return Axios.put(url(timesheet._id), timesheet)
@@ -62,49 +62,49 @@ export const removeTimesheet = (timesheet) => {
       .catch(error => {
         console.log('Error attempting to delete timesheet.');
       });
-  }
-}
+  };
+};
 
-export const restoreTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const restoreTimesheet = timesheet => {
+  return dispatch => {
     timesheet.deleted = false;
 
     return Axios.put(url(timesheet._id), timesheet)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timesheet : ' + res.data.name + ', was restored.');
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore timesheet.');
       });
-  }
-}
+  };
+};
 
-export const createTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const createTimesheet = timesheet => {
+  return dispatch => {
     return Axios.post(url(), timesheet)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timesheet : ' + res.data.name + ', created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating timesheet.');
       });
-  }
-}
+  };
+};
 
-export const list = (timesheets) => {
+export const list = timesheets => {
   return {
     type: TimesheetActionTypes.LIST,
     timesheets: timesheets
-  }
-}
+  };
+};
 
-export const get = (timesheet) => {
+export const get = timesheet => {
   return {
     type: TimesheetActionTypes.GET,
     timesheet: timesheet
-  }
-}
+  };
+};

--- a/final/src/actions/TimesheetActionCreator.test.js
+++ b/final/src/actions/TimesheetActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './TimesheetActionCreator'
-import * as types from './TimesheetActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './TimesheetActionCreator';
+import * as types from './TimesheetActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        timesheets: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      timesheets: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        timesheet: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      timesheet: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching timesheets has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['timesheet1', 'timesheet2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, timesheets: ['timesheet1', 'timesheet2']}
-    ]
-    const store = mockStore({timesheets: []})
+      { type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }
+    ];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.listTimesheets())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listTimesheets()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single timesheet', () => {
     moxios.stubRequest('/api/users/all/timesheets/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
-
-    return store.dispatch(actions.getTimesheet(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getTimesheet(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a timesheet', () => {
     moxios.stubRequest('/api/users/all/timesheets/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.updateTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a timesheet', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.removeTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a timesheet', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.restoreTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/final/src/actions/TimesheetActionCreator.test.js
+++ b/final/src/actions/TimesheetActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['timesheet1', 'timesheet2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }];
     const store = mockStore({ timesheets: [] });
 
     return store.dispatch(actions.listTimesheets()).then(() => {

--- a/final/src/actions/TimesheetActionTypes.js
+++ b/final/src/actions/TimesheetActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_TIMESHEETS";
-export const GET = "GET_TIMESHEET";
+export const LIST = 'LIST_TIMESHEETS';
+export const GET = 'GET_TIMESHEET';

--- a/final/src/actions/TimeunitActionCreator.js
+++ b/final/src/actions/TimeunitActionCreator.js
@@ -1,21 +1,19 @@
 import * as TimeunitActionTypes from './TimeunitActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/users/all/timesheets/';
 
 const url = (timesheetId, timeunitId) => {
-
   let url = apiUrl + timesheetId + '/timeunits';
   if (timeunitId) {
     url += '/' + timeunitId;
   }
 
   return url;
-}
+};
 
-export const listTimeunits = (timesheetId) => {
-  return (dispatch) => {
+export const listTimeunits = timesheetId => {
+  return dispatch => {
     return Axios.get(url(timesheetId))
       .then(response => {
         dispatch(list(response.data));
@@ -25,10 +23,10 @@ export const listTimeunits = (timesheetId) => {
         console.log('Error attempting to retrieve logged hours.');
       });
   };
-}
+};
 
 export const getTimeunit = (timesheetId, timeunitId) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url(timesheetId, timeunitId))
       .then(res => {
         dispatch(get(res.data));
@@ -37,11 +35,11 @@ export const getTimeunit = (timesheetId, timeunitId) => {
       .catch(error => {
         console.log('There was an error getting the timeunit');
       });
-  }
-}
+  };
+};
 
 export const updateTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.put(url(timesheetId, timeunit._id), timeunit)
       .then(res => {
         dispatch(get(res.data));
@@ -51,11 +49,11 @@ export const updateTimeunit = (timesheetId, timeunit) => {
       .catch(error => {
         console.log('There was an error updating the timeunit.');
       });
-  }
-}
+  };
+};
 
 export const removeTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     timeunit.deleted = true;
 
     return Axios.put(url(timesheetId, timeunit._id), timeunit)
@@ -67,50 +65,49 @@ export const removeTimeunit = (timesheetId, timeunit) => {
       .catch(error => {
         console.log('Error attempting to delete timeunit.');
       });
-  }
-}
+  };
+};
 
 export const restoreTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     timeunit.deleted = false;
 
     return Axios.put(url(timesheetId, timeunit._id), timeunit)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log(`Timesheet : ${res.data.name}, timeunit was restored.`);
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore timeunit.');
       });
-  }
-}
+  };
+};
 
 export const createTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.post(url(timesheetId), timeunit)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timeunit created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating timeunit.');
       });
-  }
-}
+  };
+};
 
-export const list = (timeunits) => {
+export const list = timeunits => {
   return {
     type: TimeunitActionTypes.LIST,
     timeunits: timeunits
-  }
-}
+  };
+};
 
-export const get = (timeunit) => {
+export const get = timeunit => {
   return {
     type: TimeunitActionTypes.GET,
     timeunit: timeunit
-  }
-}
-
+  };
+};

--- a/final/src/actions/TimeunitActionCreator.test.js
+++ b/final/src/actions/TimeunitActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['timeunit1', 'timeunit2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, timeunits: ['timeunit1', 'timeunit2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, timeunits: ['timeunit1', 'timeunit2'] }];
     const store = mockStore({ timeunits: [] });
 
     return store.dispatch(actions.listTimeunits(99)).then(() => {

--- a/final/src/actions/TimeunitActionCreator.test.js
+++ b/final/src/actions/TimeunitActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './TimeunitActionCreator'
-import * as types from './TimeunitActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './TimeunitActionCreator';
+import * as types from './TimeunitActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        timeunits: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      timeunits: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        timeunit: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      timeunit: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching timeunits has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['timeunit1', 'timeunit2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, timeunits: ['timeunit1', 'timeunit2']}
-    ]
-    const store = mockStore({timeunits: []})
+      { type: types.LIST, timeunits: ['timeunit1', 'timeunit2'] }
+    ];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.listTimeunits(99))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listTimeunits(99)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single timeunit', () => {
     moxios.stubRequest('/api/users/all/timesheets/99/timeunits/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
-
-    return store.dispatch(actions.getTimeunit(99, 1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getTimeunit(99, 1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a timeunit', () => {
     moxios.stubRequest('/api/users/all/timesheets/99/timeunits/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.updateTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a timeunit', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.removeTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a timeunit', () => {
@@ -121,16 +100,13 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.restoreTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when posting a new timeunit', () => {
@@ -139,15 +115,12 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.createTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.createTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/final/src/actions/TimeunitActionTypes.js
+++ b/final/src/actions/TimeunitActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_TIMEUNITS";
-export const GET = "GET_TIMEUNIT";
+export const LIST = 'LIST_TIMEUNITS';
+export const GET = 'GET_TIMEUNIT';

--- a/final/src/components/employees/EmployeeForm.js
+++ b/final/src/components/employees/EmployeeForm.js
@@ -1,37 +1,48 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl, ButtonGroup} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import {
+  Button,
+  FormGroup,
+  ControlLabel,
+  FormControl,
+  ButtonGroup
+} from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { withRouter } from 'react-router';
 
 class EmployeeForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     this.state = {
-      username: {value: null, valid: null},
-      email: {value: null, valid: null},
-      firstName: {value: null, valid: null},
-      lastName: {value: null, valid: null},
-      admin: {value: false, valid: null}
+      username: { value: null, valid: null },
+      email: { value: null, valid: null },
+      firstName: { value: null, valid: null },
+      lastName: { value: null, valid: null },
+      admin: { value: false, valid: null }
     };
 
     this.handleUsernameChange = this.handleUsernameChange.bind(this);
-    this.getUsernameValidationState = this.getUsernameValidationState.bind(this);
+    this.getUsernameValidationState = this.getUsernameValidationState.bind(
+      this
+    );
 
     this.handleEmailChange = this.handleEmailChange.bind(this);
     this.getEmailValidationState = this.getEmailValidationState.bind(this);
 
     this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
-    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(this);
+    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(
+      this
+    );
 
     this.handleLastNameChange = this.handleLastNameChange.bind(this);
-    this.getLastNameValidationState = this.getLastNameValidationState.bind(this);
+    this.getLastNameValidationState = this.getLastNameValidationState.bind(
+      this
+    );
 
     this.handleAdminChange = this.handleAdminChange.bind(this);
     this.getAdminValidationState = this.getAdminValidationState.bind(this);
-
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -40,16 +51,16 @@ class EmployeeForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     this.state = {
-      username: {value: nextProps.employee.username, valid: null},
-      email: {value: nextProps.employee.email, valid: null},
-      firstName: {value: nextProps.employee.firstName, valid: null},
-      lastName: {value: nextProps.employee.lastName, valid: null},
-      admin: {value: nextProps.employee.admin, valid: null}
+      username: { value: nextProps.employee.username, valid: null },
+      email: { value: nextProps.employee.email, valid: null },
+      firstName: { value: nextProps.employee.firstName, valid: null },
+      lastName: { value: nextProps.employee.lastName, valid: null },
+      admin: { value: nextProps.employee.admin, valid: null }
     };
   }
 
-  handleSave(){
-    if(this.validateAll()) {
+  handleSave() {
+    if (this.validateAll()) {
       this.props.handleSave({
         username: this.state.username.value,
         email: this.state.email.value,
@@ -69,12 +80,11 @@ class EmployeeForm extends Component {
 
   handleAdminChange(value) {
     let isValid = false;
-    if(value !== null){
+    if (value !== null) {
       isValid = true;
     }
-    return this.setState({ admin: {value: value, valid: isValid }});
+    return this.setState({ admin: { value: value, valid: isValid } });
   }
-
 
   getUsernameValidationState() {
     if (!this.state) return;
@@ -84,12 +94,11 @@ class EmployeeForm extends Component {
 
   handleUsernameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ username: {value: value, valid: isValid }});
+    return this.setState({ username: { value: value, valid: isValid } });
   }
-
 
   getEmailValidationState() {
     if (!this.state) return;
@@ -99,12 +108,11 @@ class EmployeeForm extends Component {
 
   handleEmailChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ email: {value: value, valid: isValid }});
+    return this.setState({ email: { value: value, valid: isValid } });
   }
-
 
   getFirstNameValidationState() {
     if (!this.state) return;
@@ -114,12 +122,11 @@ class EmployeeForm extends Component {
 
   handleFirstNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ firstName: {value: value, valid: isValid }});
+    return this.setState({ firstName: { value: value, valid: isValid } });
   }
-
 
   getLastNameValidationState() {
     if (!this.state) return;
@@ -129,23 +136,23 @@ class EmployeeForm extends Component {
 
   handleLastNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ lastName: {value: value, valid: isValid }});
+    return this.setState({ lastName: { value: value, valid: isValid } });
   }
 
-  validateAll(){
+  validateAll() {
     return (
-      this.state.username.value
-      && this.state.email.value
-      && this.state.firstName.value
-      && this.state.lastName.value
-      && this.state.admin.value !== null
+      this.state.username.value &&
+      this.state.email.value &&
+      this.state.firstName.value &&
+      this.state.lastName.value &&
+      this.state.admin.value !== null
     );
   }
 
-  render () {
+  render() {
     return (
       <form>
         <FormGroup
@@ -157,11 +164,10 @@ class EmployeeForm extends Component {
             type="text"
             value={this.state.username.value}
             placeholder="Enter username"
-            onChange={(e) => this.handleUsernameChange(e.target.value)}
+            onChange={e => this.handleUsernameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="email"
           validationState={this.getEmailValidationState()}
@@ -171,11 +177,10 @@ class EmployeeForm extends Component {
             type="email"
             value={this.state.email.value}
             placeholder="Enter email"
-            onChange={(e) => this.handleEmailChange(e.target.value)}
+            onChange={e => this.handleEmailChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="firstName"
           validationState={this.getFirstNameValidationState()}
@@ -185,11 +190,10 @@ class EmployeeForm extends Component {
             type="text"
             value={this.state.firstName.value}
             placeholder="Enter firstName"
-            onChange={(e) => this.handleFirstNameChange(e.target.value)}
+            onChange={e => this.handleFirstNameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="lastName"
           validationState={this.getLastNameValidationState()}
@@ -199,11 +203,10 @@ class EmployeeForm extends Component {
             type="text"
             value={this.state.lastName.value}
             placeholder="Enter lastName"
-            onChange={(e) => this.handleLastNameChange(e.target.value)}
+            onChange={e => this.handleLastNameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="admin"
           validationState={this.getAdminValidationState()}
@@ -212,13 +215,19 @@ class EmployeeForm extends Component {
           <div>
             <ButtonGroup>
               <Button
-                onClick={() => {this.handleAdminChange(true)}}
-                bsStyle={this.state.admin.value === true ? 'success' : 'default'}
+                onClick={() => {
+                  this.handleAdminChange(true);
+                }}
+                bsStyle={
+                  this.state.admin.value === true ? 'success' : 'default'
+                }
               >
                 Yes
               </Button>
               <Button
-                onClick={() => {this.handleAdminChange(false)}}
+                onClick={() => {
+                  this.handleAdminChange(false);
+                }}
                 bsStyle={this.state.admin.value === false ? 'danger' : ''}
               >
                 No
@@ -227,8 +236,14 @@ class EmployeeForm extends Component {
           </div>
           <FormControl.Feedback />
         </FormGroup>
-
-        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}> Save </Button>&nbsp;
+        <Button
+          bsStyle="success"
+          onClick={this.handleSave}
+          disabled={!this.validateAll()}
+        >
+          {' '}
+          Save{' '}
+        </Button>&nbsp;
         <LinkContainer to="/employees">
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>

--- a/final/src/components/employees/EmployeeForm.js
+++ b/final/src/components/employees/EmployeeForm.js
@@ -1,13 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {
-  Button,
-  FormGroup,
-  ControlLabel,
-  FormControl,
-  ButtonGroup
-} from 'react-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl, ButtonGroup } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { withRouter } from 'react-router';
 
@@ -24,22 +18,16 @@ class EmployeeForm extends Component {
     };
 
     this.handleUsernameChange = this.handleUsernameChange.bind(this);
-    this.getUsernameValidationState = this.getUsernameValidationState.bind(
-      this
-    );
+    this.getUsernameValidationState = this.getUsernameValidationState.bind(this);
 
     this.handleEmailChange = this.handleEmailChange.bind(this);
     this.getEmailValidationState = this.getEmailValidationState.bind(this);
 
     this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
-    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(
-      this
-    );
+    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(this);
 
     this.handleLastNameChange = this.handleLastNameChange.bind(this);
-    this.getLastNameValidationState = this.getLastNameValidationState.bind(
-      this
-    );
+    this.getLastNameValidationState = this.getLastNameValidationState.bind(this);
 
     this.handleAdminChange = this.handleAdminChange.bind(this);
     this.getAdminValidationState = this.getAdminValidationState.bind(this);
@@ -155,10 +143,7 @@ class EmployeeForm extends Component {
   render() {
     return (
       <form>
-        <FormGroup
-          controlId="username"
-          validationState={this.getUsernameValidationState()}
-        >
+        <FormGroup controlId="username" validationState={this.getUsernameValidationState()}>
           <ControlLabel>Username</ControlLabel>
           <FormControl
             type="text"
@@ -168,10 +153,7 @@ class EmployeeForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="email"
-          validationState={this.getEmailValidationState()}
-        >
+        <FormGroup controlId="email" validationState={this.getEmailValidationState()}>
           <ControlLabel>Email</ControlLabel>
           <FormControl
             type="email"
@@ -181,10 +163,7 @@ class EmployeeForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="firstName"
-          validationState={this.getFirstNameValidationState()}
-        >
+        <FormGroup controlId="firstName" validationState={this.getFirstNameValidationState()}>
           <ControlLabel>First Name</ControlLabel>
           <FormControl
             type="text"
@@ -194,10 +173,7 @@ class EmployeeForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="lastName"
-          validationState={this.getLastNameValidationState()}
-        >
+        <FormGroup controlId="lastName" validationState={this.getLastNameValidationState()}>
           <ControlLabel>Last Name</ControlLabel>
           <FormControl
             type="text"
@@ -207,10 +183,7 @@ class EmployeeForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="admin"
-          validationState={this.getAdminValidationState()}
-        >
+        <FormGroup controlId="admin" validationState={this.getAdminValidationState()}>
           <ControlLabel>Admin</ControlLabel>
           <div>
             <ButtonGroup>
@@ -218,9 +191,7 @@ class EmployeeForm extends Component {
                 onClick={() => {
                   this.handleAdminChange(true);
                 }}
-                bsStyle={
-                  this.state.admin.value === true ? 'success' : 'default'
-                }
+                bsStyle={this.state.admin.value === true ? 'success' : 'default'}
               >
                 Yes
               </Button>
@@ -236,11 +207,7 @@ class EmployeeForm extends Component {
           </div>
           <FormControl.Feedback />
         </FormGroup>
-        <Button
-          bsStyle="success"
-          onClick={this.handleSave}
-          disabled={!this.validateAll()}
-        >
+        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}>
           {' '}
           Save{' '}
         </Button>&nbsp;

--- a/final/src/components/employees/EmployeeRow.js
+++ b/final/src/components/employees/EmployeeRow.js
@@ -1,24 +1,26 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class EmployeeRow extends Component {
-
   handleClick(employee) {
-    if(employee.deleted){
+    if (employee.deleted) {
       employee.deleted = false;
-      this.props.actions.restoreEmployee(employee).then(this.props.actions.listEmployees);
-    }
-    else{
+      this.props.actions
+        .restoreEmployee(employee)
+        .then(this.props.actions.listEmployees);
+    } else {
       employee.deleted = true;
-      this.props.actions.removeEmployee(employee).then(this.props.actions.listEmployees);
+      this.props.actions
+        .removeEmployee(employee)
+        .then(this.props.actions.listEmployees);
     }
   }
 
   showDetail(employee) {
-    if(employee.deleted) {
+    if (employee.deleted) {
       console.log('You cannot edit a deleted employee.');
       return;
     }
@@ -29,22 +31,30 @@ class EmployeeRow extends Component {
   render() {
     const employee = this.props.employee;
 
-    let rowClass = "";
-    if(employee.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (employee.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(employee); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(employee);
+          e.stopPropagation();
+        }}
         bsStyle={employee.deleted ? 'success' : 'danger'}
       >
         {employee.deleted ? 'Restore' : 'Delete'}
-      </Button>);
-
+      </Button>
+    );
 
     return (
-      <tr className={rowClass} onClick={() => {this.showDetail(employee)}}>
+      <tr
+        className={rowClass}
+        onClick={() => {
+          this.showDetail(employee);
+        }}
+      >
         <td>{employee.username}</td>
         <td>{employee.email}</td>
         <td>{employee.firstName}</td>
@@ -54,7 +64,6 @@ class EmployeeRow extends Component {
       </tr>
     );
   }
-
 }
 
 EmployeeRow.propTypes = {

--- a/final/src/components/employees/EmployeeRow.js
+++ b/final/src/components/employees/EmployeeRow.js
@@ -8,14 +8,10 @@ class EmployeeRow extends Component {
   handleClick(employee) {
     if (employee.deleted) {
       employee.deleted = false;
-      this.props.actions
-        .restoreEmployee(employee)
-        .then(this.props.actions.listEmployees);
+      this.props.actions.restoreEmployee(employee).then(this.props.actions.listEmployees);
     } else {
       employee.deleted = true;
-      this.props.actions
-        .removeEmployee(employee)
-        .then(this.props.actions.listEmployees);
+      this.props.actions.removeEmployee(employee).then(this.props.actions.listEmployees);
     }
   }
 

--- a/final/src/components/employees/EmployeeRow.test.js
+++ b/final/src/components/employees/EmployeeRow.test.js
@@ -1,28 +1,26 @@
 import React from 'react';
 import EmployeeRow from './EmployeeRow';
 import { mount } from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Employee Row Component: ', () =>  {
+describe('Employee Row Component: ', () => {
+  it('should instantiate the Employee Row Component', () => {
+    const employee = {
+      username: 'fflintstone',
+      email: 'fred.flintstone@slatequarry.com',
+      firstName: 'Fred',
+      lastName: 'Flintstone',
+      admin: true
+    };
 
+    const component = mount(
+      <MemoryRouter>
+        <EmployeeRow employee={employee} />
+      </MemoryRouter>
+    );
 
-    it('should instantiate the Employee Row Component', () =>  {
-
-        const employee = {username:'fflintstone',
-                          'email':'fred.flintstone@slatequarry.com',
-                          'firstName':'Fred',
-                          'lastName':'Flintstone',
-                          'admin':true
-                         }
-
-        const component = mount(
-          <MemoryRouter><EmployeeRow employee={employee}/></MemoryRouter>
-        );
-
-        expect(component).toContainReact(<td>Flintstone</td>);
-        expect(component).toContainReact(<td>fflintstone</td>);
-        expect(component).toContainReact(<td>Yes</td>);
-
-    });
-
+    expect(component).toContainReact(<td>Flintstone</td>);
+    expect(component).toContainReact(<td>fflintstone</td>);
+    expect(component).toContainReact(<td>Yes</td>);
+  });
 });

--- a/final/src/components/employees/EmployeeTable.js
+++ b/final/src/components/employees/EmployeeTable.js
@@ -9,9 +9,7 @@ class EmployeeTable extends Component {
     const actions = this.props.actions;
 
     let employeeRows = this.props.employees.map(employee => {
-      return (
-        <EmployeeRow employee={employee} key={employee._id} actions={actions} />
-      );
+      return <EmployeeRow employee={employee} key={employee._id} actions={actions} />;
     });
 
     return (

--- a/final/src/components/employees/EmployeeTable.js
+++ b/final/src/components/employees/EmployeeTable.js
@@ -2,11 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import EmployeeRow from './EmployeeRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class EmployeeTable extends Component {
   render() {
-
     const actions = this.props.actions;
 
     let employeeRows = this.props.employees.map(employee => {
@@ -18,18 +17,16 @@ class EmployeeTable extends Component {
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Username</th>
-          <th>Email</th>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>Admin</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Username</th>
+            <th>Email</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Admin</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-          {employeeRows}
-        </tbody>
+        <tbody>{employeeRows}</tbody>
       </Table>
     );
   }

--- a/final/src/components/employees/EmployeeTable.test.js
+++ b/final/src/components/employees/EmployeeTable.test.js
@@ -1,33 +1,30 @@
 import React from 'react';
 import EmployeeTable from './EmployeeTable';
 import { mount } from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Employee Table Component: ', () =>  {
+describe('Employee Table Component: ', () => {
+  it('should instantiate the Employee Table', () => {
+    const employees = [
+      {
+        username: 'fflintstone',
+        email: 'fred.flintstone@slatequarry.com',
+        firstName: 'Fred',
+        lastName: 'Flintstone',
+        admin: true,
+        _id: 1
+      }
+    ];
 
+    const component = mount(
+      <MemoryRouter>
+        <EmployeeTable employees={employees} />
+      </MemoryRouter>
+    );
 
-    it('should instantiate the Employee Table', () =>  {
+    expect(component).toContainReact(<th>Last Name</th>);
+    expect(component).toIncludeText('Flintstone');
 
-
-        const employees = [{username:'fflintstone',
-                          'email':'fred.flintstone@slatequarry.com',
-                          'firstName':'Fred',
-                          'lastName':'Flintstone',
-                          'admin':true,
-                          '_id':1
-                         }]
-
-
-
-        const component = mount(
-                <MemoryRouter><EmployeeTable employees={employees}/></MemoryRouter>
-        );
-
-        expect(component).toContainReact(<th>Last Name</th>);
-        expect(component).toIncludeText('Flintstone');
-
-        expect(component.find('tbody tr')).toHaveLength(1);
-
+    expect(component.find('tbody tr')).toHaveLength(1);
   });
-
 });

--- a/final/src/components/employees/Employees.js
+++ b/final/src/components/employees/Employees.js
@@ -30,10 +30,7 @@ class Employees extends Component {
           </div>
         </Row>
         <Row>
-          <EmployeeTable
-            employees={this.props.employees}
-            actions={this.props.actions}
-          />
+          <EmployeeTable employees={this.props.employees} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/final/src/components/employees/Employees.js
+++ b/final/src/components/employees/Employees.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import EmployeeTable from './EmployeeTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 
 class Employees extends Component {
-
   constructor(props) {
     super(props);
 
@@ -31,26 +30,26 @@ class Employees extends Component {
           </div>
         </Row>
         <Row>
-          <EmployeeTable employees={this.props.employees} actions={this.props.actions}/>
+          <EmployeeTable
+            employees={this.props.employees}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     employees: state.employees.employees
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(EmployeeActions, dispatch)
   };
-}
+};
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Employees);
+export default connect(mapStateToProps, mapDispatchToProps)(Employees);

--- a/final/src/components/employees/Employees.test.js
+++ b/final/src/components/employees/Employees.test.js
@@ -2,19 +2,18 @@ import React from 'react';
 import Employees from './Employees';
 import { shallow, mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockStore = configureStore();
 
-describe('Employees Component: ', () =>  {
-
-  it('should instantiate the Employee Component', () =>  {
+describe('Employees Component: ', () => {
+  it('should instantiate the Employee Component', () => {
     const component = shallow(
-      <MemoryRouter><Employees store={mockStore}/></MemoryRouter>
+      <MemoryRouter>
+        <Employees store={mockStore} />
+      </MemoryRouter>
     );
 
-      expect(component).toHaveLength(1);
-
+    expect(component).toHaveLength(1);
   });
-
 });

--- a/final/src/components/employees/EmployeesCreate.js
+++ b/final/src/components/employees/EmployeesCreate.js
@@ -59,6 +59,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(EmployeesCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EmployeesCreate));

--- a/final/src/components/employees/EmployeesCreate.js
+++ b/final/src/components/employees/EmployeesCreate.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import EmployeeForm from './EmployeeForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 import { withRouter } from 'react-router';
 
 class EmployeesCreate extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listEmployees();
@@ -17,7 +16,7 @@ class EmployeesCreate extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(employee){
+  handleSave(employee) {
     this.props.actions.createEmployee(employee).then(() => {
       this.props.history.push('/employees');
     });
@@ -30,7 +29,11 @@ class EmployeesCreate extends Component {
           <PageHeader>Employees Create</PageHeader>
         </Row>
         <Row>
-          <EmployeeForm employee={this.props.employee} actions={this.props.actions} handleSave={this.handleSave}/>
+          <EmployeeForm
+            employee={this.props.employee}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
@@ -46,20 +49,16 @@ EmployeesCreate.propTypes = {
   history: PropTypes.object
 };
 
+const mapStateToProps = state => {
+  return {};
+};
 
-const mapStateToProps = (state) => {
-  return {
-  }
-}
-
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(EmployeeActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(EmployeesCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(EmployeesCreate)
+);

--- a/final/src/components/employees/EmployeesDetail.js
+++ b/final/src/components/employees/EmployeesDetail.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import EmployeeForm from './EmployeeForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 import { withRouter } from 'react-router';
 
 class EmployeesDetail extends Component {
-
   constructor(props) {
     super(props);
 
@@ -19,7 +18,7 @@ class EmployeesDetail extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(employee){
+  handleSave(employee) {
     this.props.actions.updateEmployee(employee).then(() => {
       this.props.history.push('/employees');
     });
@@ -32,7 +31,11 @@ class EmployeesDetail extends Component {
           <PageHeader>Employees Detail</PageHeader>
         </Row>
         <Row>
-          <EmployeeForm employee={this.props.employee} actions={this.props.actions} handleSave={this.handleSave}/>
+          <EmployeeForm
+            employee={this.props.employee}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
@@ -48,21 +51,18 @@ EmployeesDetail.propTypes = {
   history: PropTypes.object
 };
 
-
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     employee: state.employees.employee
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(EmployeeActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(EmployeesDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(EmployeesDetail)
+);

--- a/final/src/components/employees/EmployeesDetail.js
+++ b/final/src/components/employees/EmployeesDetail.js
@@ -63,6 +63,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(EmployeesDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EmployeesDetail));

--- a/final/src/components/employees/EmployeesDetail.test.js
+++ b/final/src/components/employees/EmployeesDetail.test.js
@@ -1,24 +1,23 @@
 import React from 'react';
 import EmployeesDetail from './EmployeesDetail';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-
-describe('Employees Detail Component: ', () =>  {
+describe('Employees Detail Component: ', () => {
   let mockStore;
 
   beforeEach(() => {
     mockStore = configureStore();
   });
 
-  it('should instantiate the Employees Detail Component', () =>  {
+  it('should instantiate the Employees Detail Component', () => {
     const component = mount(
-      <MemoryRouter><EmployeesDetail store={mockStore}/></MemoryRouter>
+      <MemoryRouter>
+        <EmployeesDetail store={mockStore} />
+      </MemoryRouter>
     );
 
     expect(component).toIncludeText('Employees Detail');
-
   });
-
 });

--- a/final/src/components/nav/Navigation.js
+++ b/final/src/components/nav/Navigation.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
-import {Navbar, Nav, NavItem} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Navbar, Nav, NavItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class NavBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      user: {_id: 'all'}
+      user: { _id: 'all' }
     };
   }
 
@@ -14,9 +14,7 @@ class NavBar extends Component {
     return (
       <Navbar>
         <Navbar.Header>
-          <Navbar.Brand>
-            Timesheetz
-          </Navbar.Brand>
+          <Navbar.Brand>Timesheetz</Navbar.Brand>
         </Navbar.Header>
         <Nav>
           <LinkContainer to="/projects">

--- a/final/src/components/nav/Navigation.test.js
+++ b/final/src/components/nav/Navigation.test.js
@@ -3,18 +3,20 @@ import { mount } from 'enzyme';
 
 import Navigation from './Navigation';
 
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
-describe('Navigation Component: ', () =>  {
-
+describe('Navigation Component: ', () => {
   let nav;
 
-  beforeEach(() =>{
-    nav = mount(<BrowserRouter><Navigation /></BrowserRouter>);
+  beforeEach(() => {
+    nav = mount(
+      <BrowserRouter>
+        <Navigation />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Navigation Component', () =>  {
+  it('should instantiate the Navigation Component', () => {
     expect(nav).toHaveLength(1);
   });
-
 });

--- a/final/src/components/projects/ProjectForm.js
+++ b/final/src/components/projects/ProjectForm.js
@@ -18,9 +18,7 @@ class ProjectForm extends Component {
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
-      this
-    );
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -79,10 +77,7 @@ class ProjectForm extends Component {
   render() {
     return (
       <form>
-        <FormGroup
-          controlId="name"
-          validationState={this.getNameValidationState()}
-        >
+        <FormGroup controlId="name" validationState={this.getNameValidationState()}>
           <ControlLabel>Name</ControlLabel>
           <FormControl
             type="text"
@@ -92,10 +87,7 @@ class ProjectForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="description"
-          validationState={this.getDescriptionValidationState()}
-        >
+        <FormGroup controlId="description" validationState={this.getDescriptionValidationState()}>
           <ControlLabel>Description</ControlLabel>
           <FormControl
             type="text"
@@ -105,11 +97,7 @@ class ProjectForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <Button
-          bsStyle="success"
-          onClick={this.handleSave}
-          disabled={!this.validateAll()}
-        >
+        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}>
           {' '}
           Save{' '}
         </Button>&nbsp;

--- a/final/src/components/projects/ProjectForm.js
+++ b/final/src/components/projects/ProjectForm.js
@@ -1,24 +1,26 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { withRouter } from 'react-router';
 
 class ProjectForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     this.state = {
-      name: {value: null, valid: null},
-      description: {value: null, valid: null}
+      name: { value: null, valid: null },
+      description: { value: null, valid: null }
     };
 
     this.handleNameChange = this.handleNameChange.bind(this);
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
+      this
+    );
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -27,13 +29,13 @@ class ProjectForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     this.state = {
-      name: {value: nextProps.project.name, valid: null},
-      description: {value: nextProps.project.description, valid: null}
+      name: { value: nextProps.project.name, valid: null },
+      description: { value: nextProps.project.description, valid: null }
     };
   }
 
-  handleSave(){
-    if(this.validateAll()) {
+  handleSave() {
+    if (this.validateAll()) {
       this.props.handleSave({
         name: this.state.name.value,
         description: this.state.description.value,
@@ -50,10 +52,10 @@ class ProjectForm extends Component {
 
   handleDescriptionChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ description: {value: value, valid: isValid }});
+    return this.setState({ description: { value: value, valid: isValid } });
   }
 
   getNameValidationState() {
@@ -64,20 +66,17 @@ class ProjectForm extends Component {
 
   handleNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ name: {value: value, valid: isValid }});
+    return this.setState({ name: { value: value, valid: isValid } });
   }
 
-  validateAll(){
-    return (
-      this.state.name.value
-      && this.state.description.value
-    );
+  validateAll() {
+    return this.state.name.value && this.state.description.value;
   }
 
-  render () {
+  render() {
     return (
       <form>
         <FormGroup
@@ -89,11 +88,10 @@ class ProjectForm extends Component {
             type="text"
             value={this.state.name.value}
             placeholder="Enter name"
-            onChange={(e) => this.handleNameChange(e.target.value)}
+            onChange={e => this.handleNameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="description"
           validationState={this.getDescriptionValidationState()}
@@ -103,12 +101,18 @@ class ProjectForm extends Component {
             type="text"
             value={this.state.description.value}
             placeholder="Enter description"
-            onChange={(e) => this.handleDescriptionChange(e.target.value)}
+            onChange={e => this.handleDescriptionChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
-        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}> Save </Button>&nbsp;
+        <Button
+          bsStyle="success"
+          onClick={this.handleSave}
+          disabled={!this.validateAll()}
+        >
+          {' '}
+          Save{' '}
+        </Button>&nbsp;
         <LinkContainer to="/projects">
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>

--- a/final/src/components/projects/ProjectRow.js
+++ b/final/src/components/projects/ProjectRow.js
@@ -7,14 +7,10 @@ class ProjectRow extends Component {
   handleClick(project) {
     if (project.deleted) {
       project.deleted = false;
-      this.props.actions
-        .restoreProject(project)
-        .then(this.props.actions.listProjects);
+      this.props.actions.restoreProject(project).then(this.props.actions.listProjects);
     } else {
       project.deleted = true;
-      this.props.actions
-        .removeProject(project)
-        .then(this.props.actions.listProjects);
+      this.props.actions.removeProject(project).then(this.props.actions.listProjects);
     }
   }
 

--- a/final/src/components/projects/ProjectRow.js
+++ b/final/src/components/projects/ProjectRow.js
@@ -1,23 +1,25 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class ProjectRow extends Component {
-
   handleClick(project) {
-    if(project.deleted){
+    if (project.deleted) {
       project.deleted = false;
-      this.props.actions.restoreProject(project).then(this.props.actions.listProjects);
-    }
-    else{
+      this.props.actions
+        .restoreProject(project)
+        .then(this.props.actions.listProjects);
+    } else {
       project.deleted = true;
-      this.props.actions.removeProject(project).then(this.props.actions.listProjects);
+      this.props.actions
+        .removeProject(project)
+        .then(this.props.actions.listProjects);
     }
   }
 
   showDetail(project) {
-    if(project.deleted) {
+    if (project.deleted) {
       console.log('You cannot edit a deleted project.');
       return;
     }
@@ -26,21 +28,30 @@ class ProjectRow extends Component {
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.project.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.project.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(this.props.project); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(this.props.project);
+          e.stopPropagation();
+        }}
         bsStyle={this.props.project.deleted ? 'success' : 'danger'}
       >
         {this.props.project.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
-      <tr className={rowClass} onClick={() => {this.showDetail(this.props.project)}}>
+      <tr
+        className={rowClass}
+        onClick={() => {
+          this.showDetail(this.props.project);
+        }}
+      >
         <td>{this.props.project.name}</td>
         <td>{this.props.project.description}</td>
         <td>{button}</td>

--- a/final/src/components/projects/ProjectRow.test.js
+++ b/final/src/components/projects/ProjectRow.test.js
@@ -2,19 +2,21 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ProjectRow from './ProjectRow';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Project Row Component: ', () =>  {
-
+describe('Project Row Component: ', () => {
   let projectRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const project = {};
-    projectRow = mount(<MemoryRouter><ProjectRow project={project} /></MemoryRouter>);
+    projectRow = mount(
+      <MemoryRouter>
+        <ProjectRow project={project} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Project Row Component', () =>  {
+  it('should instantiate the Project Row Component', () => {
     expect(projectRow).toHaveLength(1);
   });
-
 });

--- a/final/src/components/projects/ProjectTable.js
+++ b/final/src/components/projects/ProjectTable.js
@@ -2,31 +2,28 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectRow from './ProjectRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class ProjectTable extends Component {
   render() {
-
     const actions = this.props.actions;
 
     const projectRows = this.props.projects.map(project => {
       return (
-        <ProjectRow project={project} key={project._id} actions={actions}/>
+        <ProjectRow project={project} key={project._id} actions={actions} />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {projectRows}
-        </tbody>
+        <tbody>{projectRows}</tbody>
       </Table>
     );
   }

--- a/final/src/components/projects/ProjectTable.js
+++ b/final/src/components/projects/ProjectTable.js
@@ -9,9 +9,7 @@ class ProjectTable extends Component {
     const actions = this.props.actions;
 
     const projectRows = this.props.projects.map(project => {
-      return (
-        <ProjectRow project={project} key={project._id} actions={actions} />
-      );
+      return <ProjectRow project={project} key={project._id} actions={actions} />;
     });
 
     return (

--- a/final/src/components/projects/ProjectTable.test.js
+++ b/final/src/components/projects/ProjectTable.test.js
@@ -2,19 +2,21 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ProjectTable from './ProjectTable';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Project Table Component: ', () =>  {
-
+describe('Project Table Component: ', () => {
   let projectTable;
 
-  beforeEach(() =>{
-    const projects = [{_id: 1}, {_id: 2}];
-    projectTable = mount(<MemoryRouter><ProjectTable projects={projects} /></MemoryRouter>);
+  beforeEach(() => {
+    const projects = [{ _id: 1 }, { _id: 2 }];
+    projectTable = mount(
+      <MemoryRouter>
+        <ProjectTable projects={projects} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Project Table Component', () =>  {
+  it('should instantiate the Project Table Component', () => {
     expect(projectTable).toHaveLength(1);
   });
-
 });

--- a/final/src/components/projects/Projects.js
+++ b/final/src/components/projects/Projects.js
@@ -31,10 +31,7 @@ class Projects extends Component {
           </div>
         </Row>
         <Row>
-          <ProjectTable
-            projects={this.props.projects}
-            actions={this.props.actions}
-          />
+          <ProjectTable projects={this.props.projects} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/final/src/components/projects/Projects.js
+++ b/final/src/components/projects/Projects.js
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
 
 import ProjectTable from './ProjectTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
 class Projects extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listProjects();
@@ -16,9 +15,7 @@ class Projects extends Component {
     this.createProject = this.createProject.bind(this);
   }
 
-  createProject(){
-
-  }
+  createProject() {}
 
   render() {
     return (
@@ -34,26 +31,26 @@ class Projects extends Component {
           </div>
         </Row>
         <Row>
-          <ProjectTable projects={this.props.projects} actions={this.props.actions}/>
+          <ProjectTable
+            projects={this.props.projects}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     projects: state.projects.projects
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Projects);
+export default connect(mapStateToProps, mapDispatchToProps)(Projects);

--- a/final/src/components/projects/Projects.test.js
+++ b/final/src/components/projects/Projects.test.js
@@ -3,19 +3,21 @@ import { mount } from 'enzyme';
 
 import Projects from './Projects';
 import configureStore from '../../store/configure-store';
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
-describe('Projects Component: ', () =>  {
-
+describe('Projects Component: ', () => {
   let projects;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    projects = mount(<BrowserRouter><Projects store={mockStore}/></BrowserRouter>);
+  beforeEach(() => {
+    projects = mount(
+      <BrowserRouter>
+        <Projects store={mockStore} />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Project Component', () =>  {
+  it('should instantiate the Project Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/final/src/components/projects/ProjectsCreate.js
+++ b/final/src/components/projects/ProjectsCreate.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectForm from './ProjectForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 import { withRouter } from 'react-router';
 
 class ProjectsCreate extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listProjects();
@@ -17,7 +16,7 @@ class ProjectsCreate extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(project){
+  handleSave(project) {
     this.props.actions.createProject(project).then(() => {
       this.props.history.push('/projects');
     });
@@ -30,7 +29,11 @@ class ProjectsCreate extends Component {
           <PageHeader>Projects Create</PageHeader>
         </Row>
         <Row>
-          <ProjectForm project={this.props.project} actions={this.props.actions} handleSave={this.handleSave}/>
+          <ProjectForm
+            project={this.props.project}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
@@ -46,19 +49,16 @@ ProjectsCreate.defaultProps = {
   project: {}
 };
 
-const mapStateToProps = (state) => {
-  return {
-  }
-}
+const mapStateToProps = state => {
+  return {};
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ProjectsCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(ProjectsCreate)
+);

--- a/final/src/components/projects/ProjectsCreate.js
+++ b/final/src/components/projects/ProjectsCreate.js
@@ -59,6 +59,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(ProjectsCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ProjectsCreate));

--- a/final/src/components/projects/ProjectsCreate.test.js
+++ b/final/src/components/projects/ProjectsCreate.test.js
@@ -1,28 +1,29 @@
 import React from 'react';
 import ProjectsCreate from './ProjectsCreate';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
-describe('Projects Create Component: ', () =>  {
-
+describe('Projects Create Component: ', () => {
   let projects;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
+  beforeEach(() => {
     //Mock out the server call in the constructor
-    ProjectActions.listProjects = ()=>{
-      return (dispatch) => {
-      };
+    ProjectActions.listProjects = () => {
+      return dispatch => {};
     };
 
-    projects = mount(<BrowserRouter><ProjectsCreate store={mockStore}/></BrowserRouter>);
+    projects = mount(
+      <BrowserRouter>
+        <ProjectsCreate store={mockStore} />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Projects Create Component', () =>  {
+  it('should instantiate the Projects Create Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/final/src/components/projects/ProjectsDetail.js
+++ b/final/src/components/projects/ProjectsDetail.js
@@ -63,6 +63,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(ProjectsDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ProjectsDetail));

--- a/final/src/components/projects/ProjectsDetail.js
+++ b/final/src/components/projects/ProjectsDetail.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectForm from './ProjectForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 import { withRouter } from 'react-router';
 
 class ProjectsDetail extends Component {
-
   constructor(props) {
     super(props);
 
@@ -19,7 +18,7 @@ class ProjectsDetail extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(project){
+  handleSave(project) {
     this.props.actions.updateProject(project).then(() => {
       this.props.history.push('/projects');
     });
@@ -32,7 +31,11 @@ class ProjectsDetail extends Component {
           <PageHeader>Projects Detail</PageHeader>
         </Row>
         <Row>
-          <ProjectForm project={this.props.project} actions={this.props.actions} handleSave={this.handleSave}/>
+          <ProjectForm
+            project={this.props.project}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
@@ -48,20 +51,18 @@ ProjectsDetail.defaultProps = {
   project: {}
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     project: state.projects.project
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ProjectsDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(ProjectsDetail)
+);

--- a/final/src/components/projects/ProjectsDetail.test.js
+++ b/final/src/components/projects/ProjectsDetail.test.js
@@ -1,29 +1,30 @@
 import React from 'react';
 import ProjectsDetail from './ProjectsDetail';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
-describe('Projects Detail Component: ', () =>  {
-
+describe('Projects Detail Component: ', () => {
   let projects;
   const mockStore = configureStore();
-  const mockMatch = {params: {_id: 1}};
+  const mockMatch = { params: { _id: 1 } };
 
-  beforeEach(() =>{
+  beforeEach(() => {
     //Mock out the server call in the constructor
-    ProjectActions.getProject = (id)=>{
-      return (dispatch) => {
-      };
+    ProjectActions.getProject = id => {
+      return dispatch => {};
     };
 
-    projects = mount(<BrowserRouter><ProjectsDetail store={mockStore} match={mockMatch}/></BrowserRouter>);
+    projects = mount(
+      <BrowserRouter>
+        <ProjectsDetail store={mockStore} match={mockMatch} />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Projects Detail Component', () =>  {
+  it('should instantiate the Projects Detail Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/final/src/components/timesheets/TimesheetForm.js
+++ b/final/src/components/timesheets/TimesheetForm.js
@@ -1,28 +1,32 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class TimesheetForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     this.state = {
-      name: {value: null, valid: null},
-      description: {value: null, valid: null},
-      beginDate: {value: null, valid: null},
-      endDate: {value: null, valid: null}
+      name: { value: null, valid: null },
+      description: { value: null, valid: null },
+      beginDate: { value: null, valid: null },
+      endDate: { value: null, valid: null }
     };
 
     this.handleNameChange = this.handleNameChange.bind(this);
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
+      this
+    );
 
     this.handleBeginDateChange = this.handleBeginDateChange.bind(this);
-    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(this);
+    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(
+      this
+    );
 
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
     this.getEndDateValidationState = this.getEndDateValidationState.bind(this);
@@ -36,21 +40,23 @@ class TimesheetForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     this.state = {
-      name: {value: nextProps.timesheet.name, valid: null},
-      description: {value: nextProps.timesheet.description, valid: null},
-      beginDate: {value: nextProps.timesheet.beginDate, valid: null},
-      endDate: {value: nextProps.timesheet.endDate, valid: null}
+      name: { value: nextProps.timesheet.name, valid: null },
+      description: { value: nextProps.timesheet.description, valid: null },
+      beginDate: { value: nextProps.timesheet.beginDate, valid: null },
+      endDate: { value: nextProps.timesheet.endDate, valid: null }
     };
   }
 
-  handleSave(){
-    if(this.validateAll()) {
+  handleSave() {
+    if (this.validateAll()) {
       this.props.handleSave({
         name: this.state.name.value,
         description: this.state.description.value,
         beginDate: this.state.beginDate.value,
         endDate: this.state.endDate.value,
-        user_id: this.props.timesheet.user_id ?  this.props.timesheet.user_id : this.state.user_id.value,
+        user_id: this.props.timesheet.user_id
+          ? this.props.timesheet.user_id
+          : this.state.user_id.value,
         _id: this.props.timesheet._id
       });
     }
@@ -64,10 +70,10 @@ class TimesheetForm extends Component {
 
   handleDescriptionChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ description: {value: value, valid: isValid }});
+    return this.setState({ description: { value: value, valid: isValid } });
   }
 
   getNameValidationState() {
@@ -78,10 +84,10 @@ class TimesheetForm extends Component {
 
   handleNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ name: {value: value, valid: isValid }});
+    return this.setState({ name: { value: value, valid: isValid } });
   }
 
   getBeginDateValidationState() {
@@ -92,11 +98,11 @@ class TimesheetForm extends Component {
 
   handleBeginDateChange(value) {
     let isValid = false,
-        dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
-    if(dateRegExp.test(value)){
-        isValid = true;
+      dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
+    if (dateRegExp.test(value)) {
+      isValid = true;
     }
-    return this.setState({ beginDate: {value: value, valid: isValid }});
+    return this.setState({ beginDate: { value: value, valid: isValid } });
   }
 
   getEndDateValidationState() {
@@ -107,64 +113,64 @@ class TimesheetForm extends Component {
 
   handleEndDateChange(value) {
     let isValid = false,
-        dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
-    if(dateRegExp.test(value)){
-        isValid = true;
+      dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
+    if (dateRegExp.test(value)) {
+      isValid = true;
     }
-    return this.setState({ endDate: {value: value, valid: isValid }});
+    return this.setState({ endDate: { value: value, valid: isValid } });
   }
 
-  validateAll(){
+  validateAll() {
     return (
-      this.state.name.value
-      && this.state.description.value
-      && this.state.beginDate.value
-      && this.state.endDate.value
+      this.state.name.value &&
+      this.state.description.value &&
+      this.state.beginDate.value &&
+      this.state.endDate.value
     );
   }
 
   handleEmployeeChange(value) {
     let isValid = false;
-    if(value){
-        isValid = true;
+    if (value) {
+      isValid = true;
     }
-    return this.setState({ user_id: {value: value, valid: isValid }});
+    return this.setState({ user_id: { value: value, valid: isValid } });
   }
 
-  render () {
+  render() {
     return (
       <form>
         <FormGroup
           controlId="name"
           validationState={this.getNameValidationState()}
         >
-          {!this.props.timesheet._id &&
+          {!this.props.timesheet._id && (
             <div>
               <ControlLabel>Username</ControlLabel>
               <FormControl
                 componentClass="select"
-                onChange={(e) => this.handleEmployeeChange(e.target.value)}
+                onChange={e => this.handleEmployeeChange(e.target.value)}
               >
-                <option value="" disabled selected>Select an employee</option>
-                  {
-                    this.props.employees
-                      .map((employee) => {
-                          return <option value={employee._id}>{employee.username}</option>
-                      })
-                  }
+                <option value="" disabled selected>
+                  Select an employee
+                </option>
+                {this.props.employees.map(employee => {
+                  return (
+                    <option value={employee._id}>{employee.username}</option>
+                  );
+                })}
               </FormControl>
             </div>
-          }
+          )}
           <ControlLabel>Name</ControlLabel>
           <FormControl
             type="text"
             value={this.state.name.value}
             placeholder="Enter name"
-            onChange={(e) => this.handleNameChange(e.target.value)}
+            onChange={e => this.handleNameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="description"
           validationState={this.getDescriptionValidationState()}
@@ -174,11 +180,10 @@ class TimesheetForm extends Component {
             type="text"
             value={this.state.description.value}
             placeholder="Enter description"
-            onChange={(e) => this.handleDescriptionChange(e.target.value)}
+            onChange={e => this.handleDescriptionChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="beginDate"
           validationState={this.getBeginDateValidationState()}
@@ -188,11 +193,10 @@ class TimesheetForm extends Component {
             type="text"
             value={this.state.beginDate.value}
             placeholder="YYYY-MM-DD"
-            onChange={(e) => this.handleBeginDateChange(e.target.value)}
+            onChange={e => this.handleBeginDateChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="endDate"
           validationState={this.getEndDateValidationState()}
@@ -202,12 +206,18 @@ class TimesheetForm extends Component {
             type="text"
             value={this.state.endDate.value}
             placeholder="YYYY-MM-DD"
-            onChange={(e) => this.handleEndDateChange(e.target.value)}
+            onChange={e => this.handleEndDateChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
-        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}> Save </Button>&nbsp;
+        <Button
+          bsStyle="success"
+          onClick={this.handleSave}
+          disabled={!this.validateAll()}
+        >
+          {' '}
+          Save{' '}
+        </Button>&nbsp;
         <LinkContainer to="/employees/all/timesheets">
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>

--- a/final/src/components/timesheets/TimesheetForm.js
+++ b/final/src/components/timesheets/TimesheetForm.js
@@ -19,14 +19,10 @@ class TimesheetForm extends Component {
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
-      this
-    );
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
 
     this.handleBeginDateChange = this.handleBeginDateChange.bind(this);
-    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(
-      this
-    );
+    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(this);
 
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
     this.getEndDateValidationState = this.getEndDateValidationState.bind(this);
@@ -140,10 +136,7 @@ class TimesheetForm extends Component {
   render() {
     return (
       <form>
-        <FormGroup
-          controlId="name"
-          validationState={this.getNameValidationState()}
-        >
+        <FormGroup controlId="name" validationState={this.getNameValidationState()}>
           {!this.props.timesheet._id && (
             <div>
               <ControlLabel>Username</ControlLabel>
@@ -155,9 +148,7 @@ class TimesheetForm extends Component {
                   Select an employee
                 </option>
                 {this.props.employees.map(employee => {
-                  return (
-                    <option value={employee._id}>{employee.username}</option>
-                  );
+                  return <option value={employee._id}>{employee.username}</option>;
                 })}
               </FormControl>
             </div>
@@ -171,10 +162,7 @@ class TimesheetForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="description"
-          validationState={this.getDescriptionValidationState()}
-        >
+        <FormGroup controlId="description" validationState={this.getDescriptionValidationState()}>
           <ControlLabel>Description</ControlLabel>
           <FormControl
             type="text"
@@ -184,10 +172,7 @@ class TimesheetForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="beginDate"
-          validationState={this.getBeginDateValidationState()}
-        >
+        <FormGroup controlId="beginDate" validationState={this.getBeginDateValidationState()}>
           <ControlLabel>Begin Date</ControlLabel>
           <FormControl
             type="text"
@@ -197,10 +182,7 @@ class TimesheetForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="endDate"
-          validationState={this.getEndDateValidationState()}
-        >
+        <FormGroup controlId="endDate" validationState={this.getEndDateValidationState()}>
           <ControlLabel>End Date</ControlLabel>
           <FormControl
             type="text"
@@ -210,11 +192,7 @@ class TimesheetForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <Button
-          bsStyle="success"
-          onClick={this.handleSave}
-          disabled={!this.validateAll()}
-        >
+        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}>
           {' '}
           Save{' '}
         </Button>&nbsp;

--- a/final/src/components/timesheets/TimesheetRow.js
+++ b/final/src/components/timesheets/TimesheetRow.js
@@ -1,47 +1,60 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class TimesheetRow extends Component {
-
   handleClick(timesheet) {
-    if(timesheet.deleted){
+    if (timesheet.deleted) {
       timesheet.deleted = false;
-      this.props.actions.restoreTimesheet(timesheet).then(this.props.actions.listTimesheets);
-    }
-    else{
+      this.props.actions
+        .restoreTimesheet(timesheet)
+        .then(this.props.actions.listTimesheets);
+    } else {
       timesheet.deleted = true;
-      this.props.actions.removeTimesheet(timesheet).then(this.props.actions.listTimesheets);
+      this.props.actions
+        .removeTimesheet(timesheet)
+        .then(this.props.actions.listTimesheets);
     }
   }
 
   showDetail(timesheet) {
-    if(timesheet.deleted) {
+    if (timesheet.deleted) {
       console.log('You cannot edit a deleted timesheet.');
       return;
     }
 
-    this.props.history.push('/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id);
+    this.props.history.push(
+      '/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id
+    );
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.timesheet.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.timesheet.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(this.props.timesheet); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(this.props.timesheet);
+          e.stopPropagation();
+        }}
         bsStyle={this.props.timesheet.deleted ? 'success' : 'danger'}
       >
         {this.props.timesheet.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
-      <tr className={rowClass} onClick={() => {this.showDetail(this.props.timesheet)}}>
+      <tr
+        className={rowClass}
+        onClick={() => {
+          this.showDetail(this.props.timesheet);
+        }}
+      >
         <td>{this.props.timesheet.beginDate}</td>
         <td>{this.props.timesheet.endDate}</td>
         <td>{this.props.timesheet.name}</td>

--- a/final/src/components/timesheets/TimesheetRow.js
+++ b/final/src/components/timesheets/TimesheetRow.js
@@ -8,14 +8,10 @@ class TimesheetRow extends Component {
   handleClick(timesheet) {
     if (timesheet.deleted) {
       timesheet.deleted = false;
-      this.props.actions
-        .restoreTimesheet(timesheet)
-        .then(this.props.actions.listTimesheets);
+      this.props.actions.restoreTimesheet(timesheet).then(this.props.actions.listTimesheets);
     } else {
       timesheet.deleted = true;
-      this.props.actions
-        .removeTimesheet(timesheet)
-        .then(this.props.actions.listTimesheets);
+      this.props.actions.removeTimesheet(timesheet).then(this.props.actions.listTimesheets);
     }
   }
 

--- a/final/src/components/timesheets/TimesheetRow.test.js
+++ b/final/src/components/timesheets/TimesheetRow.test.js
@@ -2,20 +2,22 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import TimesheetRow from './TimesheetRow';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timesheet Row Component: ', () =>  {
-
+describe('Timesheet Row Component: ', () => {
   let timesheetRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const timesheet = {};
     const routerStub = {};
-    timesheetRow = mount(<MemoryRouter><TimesheetRow timesheet={timesheet} actions={{}} route={routerStub} /></MemoryRouter>);
+    timesheetRow = mount(
+      <MemoryRouter>
+        <TimesheetRow timesheet={timesheet} actions={{}} route={routerStub} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheetRow).toHaveLength(1);
   });
-
 });

--- a/final/src/components/timesheets/TimesheetTable.js
+++ b/final/src/components/timesheets/TimesheetTable.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimesheetRow from './TimesheetRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class TimesheetTable extends Component {
   render() {
@@ -10,24 +10,26 @@ class TimesheetTable extends Component {
 
     let timesheetRows = this.props.timesheets.map(timesheet => {
       return (
-        <TimesheetRow timesheet={timesheet} key={timesheet._id} actions={actions}/>
+        <TimesheetRow
+          timesheet={timesheet}
+          key={timesheet._id}
+          actions={actions}
+        />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Begin Date</th>
-          <th>End Date</th>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Begin Date</th>
+            <th>End Date</th>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {timesheetRows}
-        </tbody>
+        <tbody>{timesheetRows}</tbody>
       </Table>
     );
   }

--- a/final/src/components/timesheets/TimesheetTable.js
+++ b/final/src/components/timesheets/TimesheetTable.js
@@ -9,13 +9,7 @@ class TimesheetTable extends Component {
     const actions = this.props.actions;
 
     let timesheetRows = this.props.timesheets.map(timesheet => {
-      return (
-        <TimesheetRow
-          timesheet={timesheet}
-          key={timesheet._id}
-          actions={actions}
-        />
-      );
+      return <TimesheetRow timesheet={timesheet} key={timesheet._id} actions={actions} />;
     });
 
     return (

--- a/final/src/components/timesheets/TimesheetTable.test.js
+++ b/final/src/components/timesheets/TimesheetTable.test.js
@@ -2,19 +2,21 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import TimesheetTable from './TimesheetTable';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timesheet Table Component: ', () =>  {
-
+describe('Timesheet Table Component: ', () => {
   let timesheetTable;
 
-  beforeEach(() =>{
-    const timesheets = [{_id: 1}, {_id: 2}];
-    timesheetTable = mount(<MemoryRouter><TimesheetTable timesheets={timesheets} actions={{}} /></MemoryRouter>);
+  beforeEach(() => {
+    const timesheets = [{ _id: 1 }, { _id: 2 }];
+    timesheetTable = mount(
+      <MemoryRouter>
+        <TimesheetTable timesheets={timesheets} actions={{}} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timesheet Table Component', () =>  {
+  it('should instantiate the Timesheet Table Component', () => {
     expect(timesheetTable).toHaveLength(1);
   });
-
 });

--- a/final/src/components/timesheets/Timesheets.js
+++ b/final/src/components/timesheets/Timesheets.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import TimesheetTable from './TimesheetTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimesheetActions from '../../actions/TimesheetActionCreator';
-import {LinkContainer} from 'react-router-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class Timesheets extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listTimesheets();
@@ -27,27 +26,26 @@ class Timesheets extends Component {
           </div>
         </Row>
         <Row>
-          <TimesheetTable timesheets={this.props.timesheets} actions={this.props.actions}/>
+          <TimesheetTable
+            timesheets={this.props.timesheets}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timesheets: state.timesheets.timesheets
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimesheetActions, dispatch)
   };
-}
+};
 
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Timesheets);
+export default connect(mapStateToProps, mapDispatchToProps)(Timesheets);

--- a/final/src/components/timesheets/Timesheets.js
+++ b/final/src/components/timesheets/Timesheets.js
@@ -26,10 +26,7 @@ class Timesheets extends Component {
           </div>
         </Row>
         <Row>
-          <TimesheetTable
-            timesheets={this.props.timesheets}
-            actions={this.props.actions}
-          />
+          <TimesheetTable timesheets={this.props.timesheets} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/final/src/components/timesheets/Timesheets.test.js
+++ b/final/src/components/timesheets/Timesheets.test.js
@@ -3,19 +3,21 @@ import { mount } from 'enzyme';
 
 import Timesheets from './Timesheets';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timesheets Component: ', () =>  {
-
+describe('Timesheets Component: ', () => {
   let timesheets;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    timesheets = mount(<MemoryRouter><Timesheets store={mockStore}/></MemoryRouter>);
+  beforeEach(() => {
+    timesheets = mount(
+      <MemoryRouter>
+        <Timesheets store={mockStore} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheets).toHaveLength(1);
   });
-
 });

--- a/final/src/components/timesheets/TimesheetsCreate.js
+++ b/final/src/components/timesheets/TimesheetsCreate.js
@@ -29,10 +29,7 @@ class TimesheetsCreate extends Component {
           <PageHeader>Timesheet Create</PageHeader>
         </Row>
         <Row>
-          <TimesheetForm
-            employees={this.props.employees}
-            handleSave={this.handleSave}
-          />
+          <TimesheetForm employees={this.props.employees} handleSave={this.handleSave} />
         </Row>
       </Grid>
     );
@@ -60,6 +57,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimesheetsCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimesheetsCreate));

--- a/final/src/components/timesheets/TimesheetsCreate.js
+++ b/final/src/components/timesheets/TimesheetsCreate.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimesheetForm from './TimesheetForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimesheetActions from '../../actions/TimesheetActionCreator';
@@ -10,14 +10,13 @@ import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 import { withRouter } from 'react-router';
 
 class TimesheetsCreate extends Component {
-
   constructor(props) {
     super(props);
     this.props.employeeActions.listEmployees();
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(timesheet){
+  handleSave(timesheet) {
     this.props.actions.createTimesheet(timesheet).then(() => {
       this.props.history.push('/employees/all/timesheets');
     });
@@ -30,7 +29,10 @@ class TimesheetsCreate extends Component {
           <PageHeader>Timesheet Create</PageHeader>
         </Row>
         <Row>
-          <TimesheetForm employees={this.props.employees} handleSave={this.handleSave}/>
+          <TimesheetForm
+            employees={this.props.employees}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
@@ -45,21 +47,19 @@ TimesheetsCreate.defaultProps = {
   employees: []
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
-      employees: state.employees.employees
-  }
-}
+    employees: state.employees.employees
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimesheetActions, dispatch),
     employeeActions: bindActionCreators(EmployeeActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimesheetsCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimesheetsCreate)
+);

--- a/final/src/components/timesheets/TimesheetsDetail.js
+++ b/final/src/components/timesheets/TimesheetsDetail.js
@@ -42,10 +42,7 @@ class TimesheetsDetail extends Component {
         this.props.timesheet &&
           this.props.timesheet._id && (
             <Row>
-              <Timeunits
-                timesheet={this.props.timesheet}
-                actions={this.props.actions}
-              />
+              <Timeunits timesheet={this.props.timesheet} actions={this.props.actions} />
             </Row>
           )}
       </Grid>
@@ -65,6 +62,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimesheetsDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimesheetsDetail));

--- a/final/src/components/timesheets/TimesheetsDetail.js
+++ b/final/src/components/timesheets/TimesheetsDetail.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimesheetActions from '../../actions/TimesheetActionCreator';
@@ -8,7 +8,6 @@ import Timeunits from '../timeunits/Timeunits';
 import TimesheetForm from './TimesheetForm';
 
 class TimesheetsDetail extends Component {
-
   constructor(props) {
     super(props);
 
@@ -20,7 +19,7 @@ class TimesheetsDetail extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(timesheet){
+  handleSave(timesheet) {
     this.props.actions.updateTimesheet(timesheet).then(() => {
       this.props.history.push(`/employees/all/timesheets`);
     });
@@ -33,33 +32,39 @@ class TimesheetsDetail extends Component {
           <PageHeader>Timesheet Detail</PageHeader>
         </Row>
         <Row>
-          <TimesheetForm timesheet={this.props.timesheet} actions={this.props.actions} handleSave={this.handleSave}/>
+          <TimesheetForm
+            timesheet={this.props.timesheet}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
-        { //Show timeunits after the getTimesheet() call finishes loading the timesheet
-          this.props.timesheet && this.props.timesheet._id &&
-          <Row>
-            <Timeunits timesheet={this.props.timesheet} actions={this.props.actions}/>
-          </Row>
-        }
+        {//Show timeunits after the getTimesheet() call finishes loading the timesheet
+        this.props.timesheet &&
+          this.props.timesheet._id && (
+            <Row>
+              <Timeunits
+                timesheet={this.props.timesheet}
+                actions={this.props.actions}
+              />
+            </Row>
+          )}
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timesheet: state.timesheets.timesheet
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimesheetActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimesheetsDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimesheetsDetail)
+);

--- a/final/src/components/timeunits/TimeunitForm.js
+++ b/final/src/components/timeunits/TimeunitForm.js
@@ -1,27 +1,31 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class TimeunitForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     this.state = {
-      project: {value: null, valid: null},
-      dateWorked: {value: null, valid: null},
-      hoursWorked: {value: null, valid: null}
+      project: { value: null, valid: null },
+      dateWorked: { value: null, valid: null },
+      hoursWorked: { value: null, valid: null }
     };
 
     this.handleProjectChange = this.handleProjectChange.bind(this);
     this.getProjectValidationState = this.getProjectValidationState.bind(this);
 
     this.handleDateWorkedChange = this.handleDateWorkedChange.bind(this);
-    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(this);
+    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(
+      this
+    );
 
     this.handleHoursWorkedChange = this.handleHoursWorkedChange.bind(this);
-    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(this);
+    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(
+      this
+    );
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -30,14 +34,14 @@ class TimeunitForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     this.state = {
-      project: {value: nextProps.timeunit.project, valid: null},
-      dateWorked: {value: nextProps.timeunit.dateWorked, valid: null},
-      hoursWorked: {value: nextProps.timeunit.hoursWorked, valid: null}
+      project: { value: nextProps.timeunit.project, valid: null },
+      dateWorked: { value: nextProps.timeunit.dateWorked, valid: null },
+      hoursWorked: { value: nextProps.timeunit.hoursWorked, valid: null }
     };
   }
 
-  handleSave(){
-    if(this.validateAll()) {
+  handleSave() {
+    if (this.validateAll()) {
       this.props.handleSave({
         project: this.state.project.value,
         dateWorked: this.state.dateWorked.value,
@@ -56,10 +60,10 @@ class TimeunitForm extends Component {
 
   handleProjectChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ project: {value: value, valid: isValid }});
+    return this.setState({ project: { value: value, valid: isValid } });
   }
 
   getDateWorkedValidationState() {
@@ -70,11 +74,11 @@ class TimeunitForm extends Component {
 
   handleDateWorkedChange(value) {
     let isValid = false,
-        dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
-    if(dateRegExp.test(value)){
+      dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
+    if (dateRegExp.test(value)) {
       isValid = true;
     }
-    return this.setState({ dateWorked: {value: value, valid: isValid }});
+    return this.setState({ dateWorked: { value: value, valid: isValid } });
   }
 
   getHoursWorkedValidationState() {
@@ -85,21 +89,21 @@ class TimeunitForm extends Component {
 
   handleHoursWorkedChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ hoursWorked: {value: value, valid: isValid }});
+    return this.setState({ hoursWorked: { value: value, valid: isValid } });
   }
 
-  validateAll(){
+  validateAll() {
     return (
-      this.state.project.value
-      && this.state.dateWorked.value
-      && this.state.hoursWorked.value
+      this.state.project.value &&
+      this.state.dateWorked.value &&
+      this.state.hoursWorked.value
     );
   }
 
-  render () {
+  render() {
     return (
       <form>
         <FormGroup
@@ -111,19 +115,17 @@ class TimeunitForm extends Component {
             value={this.state.project.value}
             placeholder="Project1"
             componentClass="select"
-            onChange={(e) => this.handleProjectChange(e.target.value)}
+            onChange={e => this.handleProjectChange(e.target.value)}
           >
-            <option value="" disabled selected>Select a project</option>
-            {
-              this.props.projects
-              .map((project) => {
-                return <option value={project.name}>{project.name}</option>
-              })
-            }
+            <option value="" disabled selected>
+              Select a project
+            </option>
+            {this.props.projects.map(project => {
+              return <option value={project.name}>{project.name}</option>;
+            })}
           </FormControl>
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="dateWorked"
           validationState={this.getDateWorkedValidationState()}
@@ -133,11 +135,10 @@ class TimeunitForm extends Component {
             type="text"
             value={this.state.dateWorked.value}
             placeholder="YYYY-MM-DD"
-            onChange={(e) => this.handleDateWorkedChange(e.target.value)}
+            onChange={e => this.handleDateWorkedChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="hoursWorked"
           validationState={this.getHoursWorkedValidationState()}
@@ -147,13 +148,26 @@ class TimeunitForm extends Component {
             type="text"
             value={this.state.hoursWorked.value}
             placeholder="Number of hours worked"
-            onChange={(e) => this.handleHoursWorkedChange(e.target.value)}
+            onChange={e => this.handleHoursWorkedChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
-        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}> Save </Button>&nbsp;
-        <LinkContainer to={'/employees/' + this.props.userId + '/timesheets/detail/' + this.props.timesheetId}>
+        <Button
+          bsStyle="success"
+          onClick={this.handleSave}
+          disabled={!this.validateAll()}
+        >
+          {' '}
+          Save{' '}
+        </Button>&nbsp;
+        <LinkContainer
+          to={
+            '/employees/' +
+            this.props.userId +
+            '/timesheets/detail/' +
+            this.props.timesheetId
+          }
+        >
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>
       </form>

--- a/final/src/components/timeunits/TimeunitForm.js
+++ b/final/src/components/timeunits/TimeunitForm.js
@@ -18,14 +18,10 @@ class TimeunitForm extends Component {
     this.getProjectValidationState = this.getProjectValidationState.bind(this);
 
     this.handleDateWorkedChange = this.handleDateWorkedChange.bind(this);
-    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(
-      this
-    );
+    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(this);
 
     this.handleHoursWorkedChange = this.handleHoursWorkedChange.bind(this);
-    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(
-      this
-    );
+    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(this);
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -96,20 +92,13 @@ class TimeunitForm extends Component {
   }
 
   validateAll() {
-    return (
-      this.state.project.value &&
-      this.state.dateWorked.value &&
-      this.state.hoursWorked.value
-    );
+    return this.state.project.value && this.state.dateWorked.value && this.state.hoursWorked.value;
   }
 
   render() {
     return (
       <form>
-        <FormGroup
-          controlId="project"
-          validationState={this.getProjectValidationState()}
-        >
+        <FormGroup controlId="project" validationState={this.getProjectValidationState()}>
           <ControlLabel>Project</ControlLabel>
           <FormControl
             value={this.state.project.value}
@@ -126,10 +115,7 @@ class TimeunitForm extends Component {
           </FormControl>
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="dateWorked"
-          validationState={this.getDateWorkedValidationState()}
-        >
+        <FormGroup controlId="dateWorked" validationState={this.getDateWorkedValidationState()}>
           <ControlLabel>Date Worked</ControlLabel>
           <FormControl
             type="text"
@@ -139,10 +125,7 @@ class TimeunitForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="hoursWorked"
-          validationState={this.getHoursWorkedValidationState()}
-        >
+        <FormGroup controlId="hoursWorked" validationState={this.getHoursWorkedValidationState()}>
           <ControlLabel>Hours Worked</ControlLabel>
           <FormControl
             type="text"
@@ -152,21 +135,12 @@ class TimeunitForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <Button
-          bsStyle="success"
-          onClick={this.handleSave}
-          disabled={!this.validateAll()}
-        >
+        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}>
           {' '}
           Save{' '}
         </Button>&nbsp;
         <LinkContainer
-          to={
-            '/employees/' +
-            this.props.userId +
-            '/timesheets/detail/' +
-            this.props.timesheetId
-          }
+          to={'/employees/' + this.props.userId + '/timesheets/detail/' + this.props.timesheetId}
         >
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>

--- a/final/src/components/timeunits/TimeunitRow.js
+++ b/final/src/components/timeunits/TimeunitRow.js
@@ -1,51 +1,65 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class TimeunitRow extends Component {
-
   handleClick(timesheet, timeunit) {
-    if(timeunit.deleted){
+    if (timeunit.deleted) {
       timeunit.deleted = false;
-      this.props.actions.restoreTimeunit(timesheet._id, timeunit).then(()=>{
+      this.props.actions.restoreTimeunit(timesheet._id, timeunit).then(() => {
         this.props.actions.listTimeunits(timesheet._id);
       });
-    }
-    else{
+    } else {
       timeunit.deleted = true;
-      this.props.actions.removeTimeunit(timesheet._id, timeunit).then(()=>{
+      this.props.actions.removeTimeunit(timesheet._id, timeunit).then(() => {
         this.props.actions.listTimeunits(timesheet._id);
       });
     }
   }
 
   showDetail(timesheet, timeunit) {
-    if(timeunit.deleted) {
+    if (timeunit.deleted) {
       console.log('You cannot edit a deleted timeunit.');
       return;
     }
 
-    this.props.history.push('/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id + '/timeunits/detail/' + timeunit._id);
+    this.props.history.push(
+      '/employees/' +
+        timesheet.user_id +
+        '/timesheets/detail/' +
+        timesheet._id +
+        '/timeunits/detail/' +
+        timeunit._id
+    );
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.timeunit.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.timeunit.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(this.props.timesheet, this.props.timeunit); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(this.props.timesheet, this.props.timeunit);
+          e.stopPropagation();
+        }}
         bsStyle={this.props.timeunit.deleted ? 'success' : 'danger'}
       >
         {this.props.timeunit.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
-      <tr className={rowClass} onClick={() => {this.showDetail(this.props.timesheet, this.props.timeunit)}}>
+      <tr
+        className={rowClass}
+        onClick={() => {
+          this.showDetail(this.props.timesheet, this.props.timeunit);
+        }}
+      >
         <td>{this.props.timeunit.project}</td>
         <td>{this.props.timeunit.dateWorked}</td>
         <td>{this.props.timeunit.hoursWorked}</td>

--- a/final/src/components/timeunits/TimeunitRow.test.js
+++ b/final/src/components/timeunits/TimeunitRow.test.js
@@ -1,19 +1,21 @@
 import React from 'react';
 import TimeunitRow from './TimeunitRow';
-import {mount} from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timeunit Row Component: ', () =>  {
-
+describe('Timeunit Row Component: ', () => {
   let timesheetRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const timeunit = {};
-    timesheetRow = mount(<MemoryRouter><TimeunitRow timeunit={timeunit} /></MemoryRouter>);
+    timesheetRow = mount(
+      <MemoryRouter>
+        <TimeunitRow timeunit={timeunit} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the TimeunitRow Component', () =>  {
+  it('should instantiate the TimeunitRow Component', () => {
     expect(timesheetRow).toHaveLength(1);
   });
-
 });

--- a/final/src/components/timeunits/TimeunitTable.js
+++ b/final/src/components/timeunits/TimeunitTable.js
@@ -2,34 +2,36 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimeunitRow from './TimeunitRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class TimeunitTable extends Component {
   render() {
-
     const actions = this.props.actions;
 
     const timesheet = this.props.timesheet;
 
     let timeunitRows = this.props.timeunits.map(timeunit => {
       return (
-        <TimeunitRow timeunit={timeunit} timesheet={timesheet} key={timeunit._id} actions={actions}/>
+        <TimeunitRow
+          timeunit={timeunit}
+          timesheet={timesheet}
+          key={timeunit._id}
+          actions={actions}
+        />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Project</th>
-          <th>Date</th>
-          <th>Hours</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Project</th>
+            <th>Date</th>
+            <th>Hours</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {timeunitRows}
-        </tbody>
+        <tbody>{timeunitRows}</tbody>
       </Table>
     );
   }

--- a/final/src/components/timeunits/TimeunitTable.test.js
+++ b/final/src/components/timeunits/TimeunitTable.test.js
@@ -1,19 +1,21 @@
 import React from 'react';
 import TimeunitTable from './TimeunitTable';
-import {mount} from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timeunit Table Component: ', () =>  {
-
+describe('Timeunit Table Component: ', () => {
   let timeunitTable;
 
-  beforeEach(() =>{
-    const timeunits = [{_id: 1}, {_id: 2}];
-    timeunitTable = mount(<MemoryRouter><TimeunitTable timeunits={timeunits} /></MemoryRouter>);
+  beforeEach(() => {
+    const timeunits = [{ _id: 1 }, { _id: 2 }];
+    timeunitTable = mount(
+      <MemoryRouter>
+        <TimeunitTable timeunits={timeunits} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timeunit Component', () =>  {
+  it('should instantiate the Timeunit Component', () => {
     expect(timeunitTable).toHaveLength(1);
   });
-
 });

--- a/final/src/components/timeunits/Timeunits.js
+++ b/final/src/components/timeunits/Timeunits.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import TimeunitTable from './TimeunitTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimeunitActions from '../../actions/TimeunitActionCreator';
 
 class Timeunits extends Component {
-
   constructor(props) {
     super(props);
 
@@ -16,7 +15,9 @@ class Timeunits extends Component {
 
   render() {
     const timesheet = this.props.timesheet;
-    const timeunitsCreateLink = timesheet ? `/employees/${timesheet.user_id}/timesheets/detail/${timesheet._id}/timeunits/create` : '';
+    const timeunitsCreateLink = timesheet
+      ? `/employees/${timesheet.user_id}/timesheets/detail/${timesheet._id}/timeunits/create`
+      : '';
     return (
       <Grid>
         <Row>
@@ -30,27 +31,27 @@ class Timeunits extends Component {
           </div>
         </Row>
         <Row>
-          <TimeunitTable timeunits={this.props.timeunits} timesheet={this.props.timesheet} actions={this.props.actions}/>
+          <TimeunitTable
+            timeunits={this.props.timeunits}
+            timesheet={this.props.timesheet}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timeunits: state.timeunits.timeunits
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimeunitActions, dispatch)
   };
-}
+};
 
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Timeunits);
+export default connect(mapStateToProps, mapDispatchToProps)(Timeunits);

--- a/final/src/components/timeunits/Timeunits.test.js
+++ b/final/src/components/timeunits/Timeunits.test.js
@@ -1,22 +1,24 @@
 import React from 'react';
 import Timeunits from './Timeunits';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timeunits Component: ', () =>  {
-
+describe('Timeunits Component: ', () => {
   let timeunits;
   let timesheet;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    timesheet = {_id: '123'}
-    timeunits = mount(<MemoryRouter><Timeunits store={mockStore} timesheet={timesheet}/></MemoryRouter>);
+  beforeEach(() => {
+    timesheet = { _id: '123' };
+    timeunits = mount(
+      <MemoryRouter>
+        <Timeunits store={mockStore} timesheet={timesheet} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timeunit Component', () =>  {
+  it('should instantiate the Timeunit Component', () => {
     expect(timeunits).toHaveLength(1);
   });
-
 });

--- a/final/src/components/timeunits/TimeunitsCreate.js
+++ b/final/src/components/timeunits/TimeunitsCreate.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimeunitForm from './TimeunitForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimeunitActions from '../../actions/TimeunitActionCreator';
@@ -10,22 +10,25 @@ import * as ProjectActions from '../../actions/ProjectActionCreator';
 import { withRouter } from 'react-router';
 
 class TimeunitsCreate extends Component {
-
   constructor(props) {
     super(props);
     this.props.projectActions.listProjects();
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(timeunit){
+  handleSave(timeunit) {
     const timesheet = this.props.timesheet;
     this.props.actions.createTimeunit(timesheet._id, timeunit).then(() => {
-
       //Reload all of the timeunits after the save
       this.props.actions.listTimeunits(timesheet._id);
 
       //Redirect back to the detail page to see all time entries
-      this.props.history.push('/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id);
+      this.props.history.push(
+        '/employees/' +
+          timesheet.user_id +
+          '/timesheets/detail/' +
+          timesheet._id
+      );
     });
   }
 
@@ -36,9 +39,14 @@ class TimeunitsCreate extends Component {
           <PageHeader>Timeunits Create</PageHeader>
         </Row>
         <Row>
-          <TimeunitForm timesheetId={this.props.timesheet._id} userId={this.props.timesheet.user_id}
-                        timeunit={this.props.timeunit} actions={this.props.actions} handleSave={this.handleSave}
-                        projects={this.props.projects}/>
+          <TimeunitForm
+            timesheetId={this.props.timesheet._id}
+            userId={this.props.timesheet.user_id}
+            timeunit={this.props.timeunit}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+            projects={this.props.projects}
+          />
         </Row>
       </Grid>
     );
@@ -56,22 +64,20 @@ TimeunitsCreate.defaultProps = {
   projects: []
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timesheet: state.timesheets.timesheet,
     projects: state.projects.projects
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimeunitActions, dispatch),
     projectActions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimeunitsCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimeunitsCreate)
+);

--- a/final/src/components/timeunits/TimeunitsCreate.js
+++ b/final/src/components/timeunits/TimeunitsCreate.js
@@ -24,10 +24,7 @@ class TimeunitsCreate extends Component {
 
       //Redirect back to the detail page to see all time entries
       this.props.history.push(
-        '/employees/' +
-          timesheet.user_id +
-          '/timesheets/detail/' +
-          timesheet._id
+        '/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id
       );
     });
   }
@@ -78,6 +75,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimeunitsCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimeunitsCreate));

--- a/final/src/components/timeunits/TimeunitsDetail.js
+++ b/final/src/components/timeunits/TimeunitsDetail.js
@@ -26,9 +26,7 @@ class TimeunitsDetail extends Component {
       //Reload all of the timeunits after the save
       this.props.actions.listTimeunits(timesheetId);
 
-      this.props.history.push(
-        `/employees/${userId}/timesheets/detail/${timesheetId}`
-      );
+      this.props.history.push(`/employees/${userId}/timesheets/detail/${timesheetId}`);
     });
   }
 
@@ -69,6 +67,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimeunitsDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimeunitsDetail));

--- a/final/src/components/timeunits/TimeunitsDetail.js
+++ b/final/src/components/timeunits/TimeunitsDetail.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimeunitActions from '../../actions/TimeunitActionCreator';
@@ -8,7 +8,6 @@ import TimeunitForm from './TimeunitForm';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
 class TimeunitsDetail extends Component {
-
   constructor(props) {
     super(props);
 
@@ -20,15 +19,16 @@ class TimeunitsDetail extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(timeunit){
+  handleSave(timeunit) {
     const userId = this.props.match.params.user_id;
     const timesheetId = this.props.match.params.timesheet_id;
     this.props.actions.updateTimeunit(timesheetId, timeunit).then(() => {
-
       //Reload all of the timeunits after the save
       this.props.actions.listTimeunits(timesheetId);
 
-      this.props.history.push(`/employees/${userId}/timesheets/detail/${timesheetId}`);
+      this.props.history.push(
+        `/employees/${userId}/timesheets/detail/${timesheetId}`
+      );
     });
   }
 
@@ -41,29 +41,34 @@ class TimeunitsDetail extends Component {
           <PageHeader>Timeunit Edit</PageHeader>
         </Row>
         <Row>
-          <TimeunitForm projects={this.props.projects} timesheetId={timesheetId} userId={userId} timeunit={this.props.timeunit} actions={this.props.actions} handleSave={this.handleSave}/>
+          <TimeunitForm
+            projects={this.props.projects}
+            timesheetId={timesheetId}
+            userId={userId}
+            timeunit={this.props.timeunit}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timeunit: state.timeunits.timeunit,
     projects: state.projects.projects
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimeunitActions, dispatch),
     projectActions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimeunitsDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimeunitsDetail)
+);

--- a/final/src/hello/Hello.js
+++ b/final/src/hello/Hello.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 
 class Hello extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -14,7 +13,7 @@ class Hello extends Component {
       <div className="hello">
         <h1>{this.state.greeting}</h1>
         <h2>{this.props.friend}</h2>
-        <p>Congratulations!  You have created your first React component!</p>
+        <p>Congratulations! You have created your first React component!</p>
       </div>
     );
   }

--- a/final/src/hello/Hello.test.js
+++ b/final/src/hello/Hello.test.js
@@ -4,13 +4,12 @@ import renderer from 'react-test-renderer';
 
 import Hello from './Hello';
 
-describe('Hello World:', () =>  {
-
+describe('Hello World:', () => {
   it('renders without exploding', () => {
     expect(shallow(<Hello />)).toHaveLength(1);
   });
 
-  it('should render with default text', () =>  {
+  it('should render with default text', () => {
     const component = shallow(<Hello />);
 
     expect(component).toIncludeText('Howdy');
@@ -19,10 +18,8 @@ describe('Hello World:', () =>  {
     expect(component).toHaveState('greeting', 'Howdy!!');
   });
 
-  it('should render with our props', () =>  {
-    const component = shallow(
-      <Hello friend="Fred"/>
-    );
+  it('should render with our props', () => {
+    const component = shallow(<Hello friend="Fred" />);
 
     expect(component).toIncludeText('Howdy');
 
@@ -30,12 +27,9 @@ describe('Hello World:', () =>  {
     expect(component).not.toIncludeText('Partner');
   });
 
-  it('should render to match the snapshot', () =>  {
-    const component = renderer.create(
-      <Hello friend="Luke"/>
-    );
+  it('should render to match the snapshot', () => {
+    const component = renderer.create(<Hello friend="Luke" />);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
-
 });

--- a/final/src/reducers/employee-reducer.js
+++ b/final/src/reducers/employee-reducer.js
@@ -1,13 +1,13 @@
 import * as EmployeeActionTypes from '../actions/EmployeeActionTypes';
 
-export default (state = {employees: [], employee: {}}, action) => {
+export default (state = { employees: [], employee: {} }, action) => {
   switch (action.type) {
     case EmployeeActionTypes.LIST:
-      return Object.assign({}, state, {employees: action.employees});
+      return Object.assign({}, state, { employees: action.employees });
     case EmployeeActionTypes.GET:
-      return Object.assign({}, state, {employee: action.employee});
+      return Object.assign({}, state, { employee: action.employee });
 
     default:
       return state;
   }
-}
+};

--- a/final/src/reducers/index.js
+++ b/final/src/reducers/index.js
@@ -1,4 +1,4 @@
-import {combineReducers} from "redux";
+import { combineReducers } from 'redux';
 import projects from './project-reducer';
 import timesheets from './timesheet-reducer';
 import employees from './employee-reducer';

--- a/final/src/reducers/project-reducer.js
+++ b/final/src/reducers/project-reducer.js
@@ -1,13 +1,13 @@
 import * as ProjectActionTypes from '../actions/ProjectActionTypes';
 
-export default (state = {projects: [], project: {}}, action) => {
+export default (state = { projects: [], project: {} }, action) => {
   switch (action.type) {
     case ProjectActionTypes.LIST:
-      return Object.assign({}, state, {projects: action.projects});
+      return Object.assign({}, state, { projects: action.projects });
     case ProjectActionTypes.GET:
-      return Object.assign({}, state, {project: action.project});
+      return Object.assign({}, state, { project: action.project });
 
     default:
       return state;
   }
-}
+};

--- a/final/src/reducers/timesheet-reducer.js
+++ b/final/src/reducers/timesheet-reducer.js
@@ -1,15 +1,15 @@
 import * as TimesheetActionTypes from '../actions/TimesheetActionTypes';
 import * as EmployeeActionTypes from '../actions/EmployeeActionTypes';
 
-export default (state = {timesheets: [], timesheet: {}}, action) => {
+export default (state = { timesheets: [], timesheet: {} }, action) => {
   switch (action.type) {
     case TimesheetActionTypes.LIST:
-      return Object.assign({}, state, {timesheets: action.timesheets});
+      return Object.assign({}, state, { timesheets: action.timesheets });
     case TimesheetActionTypes.GET:
-      return Object.assign({}, state, {timesheet: action.timesheet});
+      return Object.assign({}, state, { timesheet: action.timesheet });
     case EmployeeActionTypes.LIST:
-      return Object.assign({}, state, {employees: action.employees});
+      return Object.assign({}, state, { employees: action.employees });
     default:
       return state;
   }
-}
+};

--- a/final/src/reducers/timeunit-reducer.js
+++ b/final/src/reducers/timeunit-reducer.js
@@ -1,16 +1,16 @@
 import * as TimeunitActionTypes from '../actions/TimeunitActionTypes';
 import * as ProjectActionTypes from '../actions/ProjectActionTypes';
 
-export default (state = {timeunits: [], timeunit: {}}, action) => {
+export default (state = { timeunits: [], timeunit: {} }, action) => {
   switch (action.type) {
     case TimeunitActionTypes.LIST:
-      return Object.assign({}, state, {timeunits: action.timeunits});
+      return Object.assign({}, state, { timeunits: action.timeunits });
     case TimeunitActionTypes.GET:
-      return Object.assign({}, state, {timeunit: action.timeunit});
+      return Object.assign({}, state, { timeunit: action.timeunit });
     case ProjectActionTypes.LIST:
-      return Object.assign({}, state, {projects: action.projects});
+      return Object.assign({}, state, { projects: action.projects });
 
     default:
       return state;
   }
-}
+};

--- a/final/src/setupTests.js
+++ b/final/src/setupTests.js
@@ -2,9 +2,9 @@
 //See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#initializing-test-environment
 
 import 'jest-enzyme';
-import { configure } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 configure({
   adapter: new Adapter()
-})
+});

--- a/final/src/store/configure-store.js
+++ b/final/src/store/configure-store.js
@@ -1,9 +1,7 @@
 import rootReducer from '../reducers';
-import {createStore, applyMiddleware} from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
-export default (initialState = {projects: []}) => {
-  return createStore(rootReducer, initialState,
-    applyMiddleware(thunk)
-  );
+export default (initialState = { projects: [] }) => {
+  return createStore(rootReducer, initialState, applyMiddleware(thunk));
 };

--- a/lab-01-project-setup/src/App.js
+++ b/lab-01-project-setup/src/App.js
@@ -5,7 +5,6 @@ class App extends Component {
   render() {
     return (
       <div className="App">
-
         <h1>Welcome to the ReactJS Workshop</h1>
         <h2>Let's learn some React/Redux</h2>
       </div>

--- a/lab-01-project-setup/src/index.js
+++ b/lab-01-project-setup/src/index.js
@@ -3,7 +3,4 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
-);
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/lab-02-first-component/src/App.js
+++ b/lab-02-first-component/src/App.js
@@ -3,12 +3,7 @@ import './App.css';
 
 class App extends Component {
   render() {
-    return (
-      <div className="App">
-
-
-      </div>
-    );
+    return <div className="App" />;
   }
 }
 

--- a/lab-02-first-component/src/index.js
+++ b/lab-02-first-component/src/index.js
@@ -3,7 +3,4 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
-);
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/lab-02-first-component/src/setupTests.js
+++ b/lab-02-first-component/src/setupTests.js
@@ -2,9 +2,9 @@
 //See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#initializing-test-environment
 
 import 'jest-enzyme';
-import { configure } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 configure({
   adapter: new Adapter()
-})
+});

--- a/lab-03-routing/src/App.js
+++ b/lab-03-routing/src/App.js
@@ -3,9 +3,10 @@ import React, { Component } from 'react';
 import './App.css';
 
 class App extends Component {
-
   // TODO - actually implement this for realz
-  render() {return (<div />);}
+  render() {
+    return <div />;
+  }
 }
 
 export default App;

--- a/lab-03-routing/src/components/employees/EmployeeRow.js
+++ b/lab-03-routing/src/components/employees/EmployeeRow.js
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class EmployeeRow extends Component {
-
   // TODO - actually implement this for realz
-  render() {return (<div />);}
+  render() {
+    return <div />;
+  }
 }
 
 EmployeeRow.propTypes = {

--- a/lab-03-routing/src/components/employees/EmployeeRow.test.js
+++ b/lab-03-routing/src/components/employees/EmployeeRow.test.js
@@ -2,11 +2,8 @@ import React from 'react';
 import EmployeeRow from './EmployeeRow';
 import { shallow } from 'enzyme';
 
-
 describe('Employee Row Component: ', () => {
-
   it('implement me', () => {
     expect(true).toBe(true);
   });
-
 });

--- a/lab-03-routing/src/components/employees/EmployeeTable.js
+++ b/lab-03-routing/src/components/employees/EmployeeTable.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import EmployeeRow from './EmployeeRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class EmployeeTable extends Component {
-
   // TODO - actually implement this for realz
-  render() {return (<div />);}
+  render() {
+    return <div />;
+  }
 }
 
 export default EmployeeTable;

--- a/lab-03-routing/src/components/employees/EmployeeTable.test.js
+++ b/lab-03-routing/src/components/employees/EmployeeTable.test.js
@@ -3,9 +3,7 @@ import EmployeeTable from './EmployeeTable';
 import { mount } from 'enzyme';
 
 describe('Employee Table Component: ', () => {
-
-  it('implement me',  () => {
+  it('implement me', () => {
     expect(true).toBe(true);
   });
-
 });

--- a/lab-03-routing/src/components/employees/Employees.js
+++ b/lab-03-routing/src/components/employees/Employees.js
@@ -1,29 +1,28 @@
 import React, { Component } from 'react';
 
 class Employees extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
       pageConfig: {
         data: [
           {
-            "_id": 1,
-            "username": "admin",
-            "email": "admin@mixtape.com",
-            "password": "password",
-            "admin": true,
-            "firstName": "Admin",
-            "lastName": "User"
+            _id: 1,
+            username: 'admin',
+            email: 'admin@mixtape.com',
+            password: 'password',
+            admin: true,
+            firstName: 'Admin',
+            lastName: 'User'
           },
           {
-            "_id": 2,
-            "username": "user",
-            "email": "user@mixtape.com",
-            "password": "password",
-            "admin": false,
-            "firstName": "Normal",
-            "lastName": "User"
+            _id: 2,
+            username: 'user',
+            email: 'user@mixtape.com',
+            password: 'password',
+            admin: false,
+            firstName: 'Normal',
+            lastName: 'User'
           }
         ]
       }
@@ -31,7 +30,9 @@ class Employees extends Component {
   }
 
   // TODO - actually implement this for realz
-  render() {return (<div />);}
+  render() {
+    return <div />;
+  }
 }
 
 export default Employees;

--- a/lab-03-routing/src/components/employees/Employees.test.js
+++ b/lab-03-routing/src/components/employees/Employees.test.js
@@ -3,9 +3,7 @@ import Employees from './Employees';
 import { shallow, mount } from 'enzyme';
 
 describe('Employees Component: ', () => {
-
   it('implement me', () => {
     expect(true).toBe(true);
   });
-
 });

--- a/lab-03-routing/src/components/nav/Navigation.js
+++ b/lab-03-routing/src/components/nav/Navigation.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 
 class Navigation extends Component {
-
   // TODO - actually implement this for realz
-  render() {return (<div />);}
+  render() {
+    return <div />;
+  }
 }
 
 export default Navigation;

--- a/lab-03-routing/src/components/nav/Navigation.test.js
+++ b/lab-03-routing/src/components/nav/Navigation.test.js
@@ -2,12 +2,10 @@ import React from 'react';
 import Navigation from './Navigation';
 import { mount } from 'enzyme';
 
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
-describe('Navigation Component: ', () =>  {
-
-  it('implement me', () =>  {
+describe('Navigation Component: ', () => {
+  it('implement me', () => {
     expect(true).toBe(true);
   });
-
 });

--- a/lab-03-routing/src/components/projects/ProjectRow.js
+++ b/lab-03-routing/src/components/projects/ProjectRow.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class ProjectRow extends Component {
-
   render() {
     return (
       <tr>

--- a/lab-03-routing/src/components/projects/ProjectRow.test.js
+++ b/lab-03-routing/src/components/projects/ProjectRow.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import ProjectRow from './ProjectRow';
 
-describe('Project Row Component: ', () =>  {
-
+describe('Project Row Component: ', () => {
   let projectRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const project = {};
     projectRow = shallow(<ProjectRow project={project} />);
   });
 
-  it('should instantiate the Project Row Component', () =>  {
+  it('should instantiate the Project Row Component', () => {
     expect(projectRow).toHaveLength(1);
   });
-
 });

--- a/lab-03-routing/src/components/projects/ProjectTable.js
+++ b/lab-03-routing/src/components/projects/ProjectTable.js
@@ -2,29 +2,25 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectRow from './ProjectRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class ProjectTable extends Component {
   render() {
     let key = 1;
 
     let projectRows = this.props.projects.map(project => {
-      return (
-        <ProjectRow project={project} key={++key} />
-      );
+      return <ProjectRow project={project} key={++key} />;
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-        </tr>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+          </tr>
         </thead>
-        <tbody>
-        {projectRows}
-        </tbody>
+        <tbody>{projectRows}</tbody>
       </Table>
     );
   }

--- a/lab-03-routing/src/components/projects/ProjectTable.test.js
+++ b/lab-03-routing/src/components/projects/ProjectTable.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import ProjectTable from './ProjectTable';
 
-describe('Project Table Component: ', () =>  {
-
+describe('Project Table Component: ', () => {
   let projectTable;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const projects = [{}, {}];
     projectTable = shallow(<ProjectTable projects={projects} />);
   });
 
-  it('should instantiate the Project Table Component', () =>  {
+  it('should instantiate the Project Table Component', () => {
     expect(projectTable).toHaveLength(1);
   });
-
 });

--- a/lab-03-routing/src/components/projects/Projects.js
+++ b/lab-03-routing/src/components/projects/Projects.js
@@ -1,17 +1,16 @@
 import React, { Component } from 'react';
 import ProjectTable from './ProjectTable';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 
 class Projects extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
       pageConfig: {
         data: [
-          {"name": "Project1", "description": "This is your first project"},
-          {"name": "Project2", "description": "This is your second project"},
-          {"name": "Project3", "description": "This is the third project"}
+          { name: 'Project1', description: 'This is your first project' },
+          { name: 'Project2', description: 'This is your second project' },
+          { name: 'Project3', description: 'This is the third project' }
         ]
       }
     };
@@ -24,7 +23,7 @@ class Projects extends Component {
           <PageHeader>Projects</PageHeader>
         </Row>
         <Row>
-          <ProjectTable projects={this.state.pageConfig.data}/>
+          <ProjectTable projects={this.state.pageConfig.data} />
         </Row>
       </Grid>
     );

--- a/lab-03-routing/src/components/projects/Projects.test.js
+++ b/lab-03-routing/src/components/projects/Projects.test.js
@@ -3,16 +3,14 @@ import { shallow } from 'enzyme';
 
 import Projects from './Projects';
 
-describe('Projects Component: ', () =>  {
-
+describe('Projects Component: ', () => {
   let projects;
 
-  beforeEach(() =>{
-    projects = shallow(<Projects/>);
+  beforeEach(() => {
+    projects = shallow(<Projects />);
   });
 
-  it('should instantiate the Project Component', () =>  {
+  it('should instantiate the Project Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/lab-03-routing/src/components/timesheets/TimesheetRow.js
+++ b/lab-03-routing/src/components/timesheets/TimesheetRow.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class TimesheetRow extends Component {
-
   render() {
     const timesheet = this.props.timesheet;
     return (

--- a/lab-03-routing/src/components/timesheets/TimesheetRow.test.js
+++ b/lab-03-routing/src/components/timesheets/TimesheetRow.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import TimesheetRow from './TimesheetRow';
 
-describe('Timesheet Row Component: ', () =>  {
-
+describe('Timesheet Row Component: ', () => {
   let timesheetRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const timesheet = {};
     timesheetRow = shallow(<TimesheetRow timesheet={timesheet} />);
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheetRow).toHaveLength(1);
   });
-
 });

--- a/lab-03-routing/src/components/timesheets/TimesheetTable.js
+++ b/lab-03-routing/src/components/timesheets/TimesheetTable.js
@@ -2,31 +2,27 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimesheetRow from './TimesheetRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class TimesheetTable extends Component {
   render() {
     let key = 1;
 
     let timesheetRows = this.props.timesheets.map(timesheet => {
-      return (
-        <TimesheetRow timesheet={timesheet} key={++key} />
-      );
+      return <TimesheetRow timesheet={timesheet} key={++key} />;
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Begin Date</th>
-          <th>End Date</th>
-          <th>Name</th>
-          <th>Description</th>
-        </tr>
+          <tr>
+            <th>Begin Date</th>
+            <th>End Date</th>
+            <th>Name</th>
+            <th>Description</th>
+          </tr>
         </thead>
-        <tbody>
-        {timesheetRows}
-        </tbody>
+        <tbody>{timesheetRows}</tbody>
       </Table>
     );
   }

--- a/lab-03-routing/src/components/timesheets/TimesheetTable.test.js
+++ b/lab-03-routing/src/components/timesheets/TimesheetTable.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import TimesheetTable from './TimesheetTable';
 
-describe('Timesheet Table Component: ', () =>  {
-
+describe('Timesheet Table Component: ', () => {
   let timesheetTable;
 
-  beforeEach(() =>{
-    const timesheets = [{_id: 1}, {_id: 2}];
+  beforeEach(() => {
+    const timesheets = [{ _id: 1 }, { _id: 2 }];
     timesheetTable = shallow(<TimesheetTable timesheets={timesheets} />);
   });
 
-  it('should instantiate the Timesheet Table Component', () =>  {
+  it('should instantiate the Timesheet Table Component', () => {
     expect(timesheetTable).toHaveLength(1);
   });
-
 });

--- a/lab-03-routing/src/components/timesheets/Timesheets.js
+++ b/lab-03-routing/src/components/timesheets/Timesheets.js
@@ -1,155 +1,374 @@
 import React, { Component } from 'react';
 import TimesheetTable from './TimesheetTable';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 
 class Timesheets extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
       pageConfig: {
         data: [
           {
-            "name": "UserOne",
-            "beginDate": "2013-11-18T00:00:00.000Z",
-            "endDate": "2013-11-24T00:00:00.000Z",
-            "description": "Timesheet one for user",
-            "timeunits": [
-              {"dateWorked": "2013-11-18T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-11-19T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-11-20T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-11-21T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-11-22T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"}
+            name: 'UserOne',
+            beginDate: '2013-11-18T00:00:00.000Z',
+            endDate: '2013-11-24T00:00:00.000Z',
+            description: 'Timesheet one for user',
+            timeunits: [
+              {
+                dateWorked: '2013-11-18T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-11-19T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-11-20T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-11-21T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-11-22T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              }
             ]
           },
           {
-            "name": "UserTwo",
-            "beginDate": "2013-11-25T00:00:00.000Z",
-            "endDate": "2013-12-01T00:00:00.000Z",
-            "description": "Timesheet two for user",
-            "timeunits": [
-              {"dateWorked": "2013-11-25T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-11-26T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-11-27T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-11-28T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-11-29T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"}
+            name: 'UserTwo',
+            beginDate: '2013-11-25T00:00:00.000Z',
+            endDate: '2013-12-01T00:00:00.000Z',
+            description: 'Timesheet two for user',
+            timeunits: [
+              {
+                dateWorked: '2013-11-25T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-11-26T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-11-27T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-11-28T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-11-29T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              }
             ]
           },
           {
-            "name": "UserThree",
-            "beginDate": "2013-12-02T00:00:00.000Z",
-            "endDate": "2013-12-08T00:00:00.000Z",
-            "description": "Timesheet three for user",
-            "timeunits": [
-              {"dateWorked": "2013-12-02T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-12-03T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-12-04T00:00:00.000Z", "hoursWorked": 8, "project": "Project1"},
-              {"dateWorked": "2013-12-05T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-06T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"}
+            name: 'UserThree',
+            beginDate: '2013-12-02T00:00:00.000Z',
+            endDate: '2013-12-08T00:00:00.000Z',
+            description: 'Timesheet three for user',
+            timeunits: [
+              {
+                dateWorked: '2013-12-02T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-12-03T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-12-04T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project1'
+              },
+              {
+                dateWorked: '2013-12-05T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-06T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              }
             ]
           },
           {
-            "name": "UserFour",
-            "beginDate": "2013-12-09T00:00:00.000Z",
-            "endDate": "2013-12-15T00:00:00.000Z",
-            "description": "Timesheet four for user",
-            "timeunits": [
-              {"dateWorked": "2013-12-09T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-10T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-11T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-12T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-13T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"}
+            name: 'UserFour',
+            beginDate: '2013-12-09T00:00:00.000Z',
+            endDate: '2013-12-15T00:00:00.000Z',
+            description: 'Timesheet four for user',
+            timeunits: [
+              {
+                dateWorked: '2013-12-09T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-10T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-11T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-12T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-13T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              }
             ]
           },
           {
-            "name": "UserFive",
-            "beginDate": "2013-12-16T00:00:00.000Z",
-            "endDate": "2013-12-22T00:00:00.000Z",
-            "description": "Timesheet five for user",
-            "timeunits": [
-              {"dateWorked": "2013-12-16T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-17T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-18T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-19T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-20T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"}
+            name: 'UserFive',
+            beginDate: '2013-12-16T00:00:00.000Z',
+            endDate: '2013-12-22T00:00:00.000Z',
+            description: 'Timesheet five for user',
+            timeunits: [
+              {
+                dateWorked: '2013-12-16T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-17T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-18T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-19T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-20T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              }
             ]
           },
           {
-            "name": "UserSix",
-            "beginDate": "2013-12-23T00:00:00.000Z",
-            "endDate": "2013-12-29T00:00:00.000Z",
-            "description": "Timesheet six for user",
-            "timeunits": [
-              {"dateWorked": "2013-12-23T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-24T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-25T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-26T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"},
-              {"dateWorked": "2013-12-27T00:00:00.000Z", "hoursWorked": 8, "project": "Project2"}
+            name: 'UserSix',
+            beginDate: '2013-12-23T00:00:00.000Z',
+            endDate: '2013-12-29T00:00:00.000Z',
+            description: 'Timesheet six for user',
+            timeunits: [
+              {
+                dateWorked: '2013-12-23T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-24T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-25T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-26T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              },
+              {
+                dateWorked: '2013-12-27T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project2'
+              }
             ]
           },
           {
-            "name": "UserSeven",
-            "beginDate": "2013-12-30T00:00:00.000Z",
-            "endDate": "2013-01-05T00:00:00.000Z",
-            "description": "Timesheet seven for user",
-            "timeunits": [
-              {"dateWorked": "2013-12-30T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-12-31T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-01T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-02T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-03T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"}
+            name: 'UserSeven',
+            beginDate: '2013-12-30T00:00:00.000Z',
+            endDate: '2013-01-05T00:00:00.000Z',
+            description: 'Timesheet seven for user',
+            timeunits: [
+              {
+                dateWorked: '2013-12-30T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-12-31T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-01T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-02T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-03T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              }
             ]
           },
           {
-            "name": "UserEight",
-            "beginDate": "2013-01-06T00:00:00.000Z",
-            "endDate": "2013-01-12T00:00:00.000Z",
-            "description": "Timesheet eight for user",
-            "timeunits": [
-              {"dateWorked": "2013-01-06T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-07T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-08T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-09T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-10T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"}
+            name: 'UserEight',
+            beginDate: '2013-01-06T00:00:00.000Z',
+            endDate: '2013-01-12T00:00:00.000Z',
+            description: 'Timesheet eight for user',
+            timeunits: [
+              {
+                dateWorked: '2013-01-06T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-07T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-08T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-09T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-10T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              }
             ]
           },
           {
-            "name": "UserNine",
-            "beginDate": "2013-01-13T00:00:00.000Z",
-            "endDate": "2013-01-19T00:00:00.000Z",
-            "description": "Timesheet nine for user",
-            "timeunits": [
-              {"dateWorked": "2013-01-13T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-14T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-15T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-16T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-17T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"}
+            name: 'UserNine',
+            beginDate: '2013-01-13T00:00:00.000Z',
+            endDate: '2013-01-19T00:00:00.000Z',
+            description: 'Timesheet nine for user',
+            timeunits: [
+              {
+                dateWorked: '2013-01-13T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-14T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-15T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-16T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-17T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              }
             ]
           },
           {
-            "name": "UserTen",
-            "beginDate": "2013-01-20T00:00:00.000Z",
-            "endDate": "2013-01-26T00:00:00.000Z",
-            "description": "Timesheet ten for user",
-            "timeunits": [
-              {"dateWorked": "2013-01-20T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-21T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-22T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-23T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-24T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"}
+            name: 'UserTen',
+            beginDate: '2013-01-20T00:00:00.000Z',
+            endDate: '2013-01-26T00:00:00.000Z',
+            description: 'Timesheet ten for user',
+            timeunits: [
+              {
+                dateWorked: '2013-01-20T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-21T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-22T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-23T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-24T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              }
             ]
           },
           {
-            "name": "UserEleven",
-            "beginDate": "2013-01-27T00:00:00.000Z",
-            "endDate": "2013-02-02T00:00:00.000Z",
-            "description": "Timesheet eleven for user",
-            "timeunits": [
-              {"dateWorked": "2013-01-27T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-28T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-29T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-30T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"},
-              {"dateWorked": "2013-01-31T00:00:00.000Z", "hoursWorked": 8, "project": "Project3"}
+            name: 'UserEleven',
+            beginDate: '2013-01-27T00:00:00.000Z',
+            endDate: '2013-02-02T00:00:00.000Z',
+            description: 'Timesheet eleven for user',
+            timeunits: [
+              {
+                dateWorked: '2013-01-27T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-28T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-29T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-30T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              },
+              {
+                dateWorked: '2013-01-31T00:00:00.000Z',
+                hoursWorked: 8,
+                project: 'Project3'
+              }
             ]
           }
         ]
@@ -164,7 +383,7 @@ class Timesheets extends Component {
           <PageHeader>Timesheets</PageHeader>
         </Row>
         <Row>
-          <TimesheetTable timesheets={this.state.pageConfig.data}/>
+          <TimesheetTable timesheets={this.state.pageConfig.data} />
         </Row>
       </Grid>
     );

--- a/lab-03-routing/src/components/timesheets/Timesheets.test.js
+++ b/lab-03-routing/src/components/timesheets/Timesheets.test.js
@@ -3,16 +3,14 @@ import { shallow } from 'enzyme';
 
 import Timesheets from './Timesheets';
 
-describe('Timesheets Component: ', () =>  {
-
+describe('Timesheets Component: ', () => {
   let timesheets;
 
-  beforeEach(() =>{
-    timesheets = shallow(<Timesheets/>);
+  beforeEach(() => {
+    timesheets = shallow(<Timesheets />);
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheets).toHaveLength(1);
   });
-
 });

--- a/lab-03-routing/src/hello/Hello.js
+++ b/lab-03-routing/src/hello/Hello.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 
 class Hello extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -14,7 +13,7 @@ class Hello extends Component {
       <div className="hello">
         <h1>{this.state.greeting}</h1>
         <h2>{this.props.friend}</h2>
-        <p>Congratulations!  You have created your first React component!</p>
+        <p>Congratulations! You have created your first React component!</p>
       </div>
     );
   }

--- a/lab-03-routing/src/hello/Hello.test.js
+++ b/lab-03-routing/src/hello/Hello.test.js
@@ -4,13 +4,12 @@ import renderer from 'react-test-renderer';
 
 import Hello from './Hello';
 
-describe('Hello World:', () =>  {
-
+describe('Hello World:', () => {
   it('renders without exploding', () => {
     expect(shallow(<Hello />)).toHaveLength(1);
   });
 
-  it('should render with default text', () =>  {
+  it('should render with default text', () => {
     const component = shallow(<Hello />);
 
     expect(component).toIncludeText('Howdy');
@@ -19,10 +18,8 @@ describe('Hello World:', () =>  {
     expect(component).toHaveState('greeting', 'Howdy!!');
   });
 
-  it('should render with our props', () =>  {
-    const component = shallow(
-      <Hello friend="Fred"/>
-    );
+  it('should render with our props', () => {
+    const component = shallow(<Hello friend="Fred" />);
 
     expect(component).toIncludeText('Howdy');
 
@@ -30,12 +27,9 @@ describe('Hello World:', () =>  {
     expect(component).not.toIncludeText('Partner');
   });
 
-  it('should render to match the snapshot', () =>  {
-    const component = renderer.create(
-      <Hello friend="Luke"/>
-    );
+  it('should render to match the snapshot', () => {
+    const component = renderer.create(<Hello friend="Luke" />);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
-
 });

--- a/lab-03-routing/src/index.js
+++ b/lab-03-routing/src/index.js
@@ -3,7 +3,4 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
 
-ReactDOM.render(
-  <App />,
-  document.getElementById('root')
-);
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/lab-03-routing/src/setupTests.js
+++ b/lab-03-routing/src/setupTests.js
@@ -2,9 +2,9 @@
 //See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#initializing-test-environment
 
 import 'jest-enzyme';
-import { configure } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 configure({
   adapter: new Adapter()
-})
+});

--- a/lab-04-redux/src/App.js
+++ b/lab-04-redux/src/App.js
@@ -4,19 +4,22 @@ import Projects from './components/projects/Projects';
 import Employees from './components/employees/Employees';
 import Timesheets from './components/timesheets/Timesheets';
 import Navigation from './components/nav/Navigation';
-import {BrowserRouter, Route, Switch, Redirect} from 'react-router-dom';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 
 class App extends Component {
   render() {
     return (
       <BrowserRouter>
         <div className="App">
-          <Navigation/>
+          <Navigation />
           <Switch>
-            <Route path="/projects" component={Projects}/>
-            <Route exact path="/employees" component={Employees}/>
-            <Route path="/employees/:user_id/timesheets" component={Timesheets}/>
-            <Redirect to="/employees"/>
+            <Route path="/projects" component={Projects} />
+            <Route exact path="/employees" component={Employees} />
+            <Route
+              path="/employees/:user_id/timesheets"
+              component={Timesheets}
+            />
+            <Redirect to="/employees" />
           </Switch>
         </div>
       </BrowserRouter>

--- a/lab-04-redux/src/App.js
+++ b/lab-04-redux/src/App.js
@@ -15,10 +15,7 @@ class App extends Component {
           <Switch>
             <Route path="/projects" component={Projects} />
             <Route exact path="/employees" component={Employees} />
-            <Route
-              path="/employees/:user_id/timesheets"
-              component={Timesheets}
-            />
+            <Route path="/employees/:user_id/timesheets" component={Timesheets} />
             <Redirect to="/employees" />
           </Switch>
         </div>

--- a/lab-04-redux/src/App.test.js
+++ b/lab-04-redux/src/App.test.js
@@ -11,9 +11,6 @@ describe('App Component', () => {
   it('renders with our expected text', () => {
     const result = shallow(<App />);
 
-    expect(result.find('Route').at(2)).toHaveProp(
-      'path',
-      '/employees/:user_id/timesheets'
-    );
+    expect(result.find('Route').at(2)).toHaveProp('path', '/employees/:user_id/timesheets');
   });
 });

--- a/lab-04-redux/src/App.test.js
+++ b/lab-04-redux/src/App.test.js
@@ -9,10 +9,11 @@ describe('App Component', () => {
   });
 
   it('renders with our expected text', () => {
-
     const result = shallow(<App />);
 
-    expect(result.find('Route').at(2)).toHaveProp('path', '/employees/:user_id/timesheets');
-
+    expect(result.find('Route').at(2)).toHaveProp(
+      'path',
+      '/employees/:user_id/timesheets'
+    );
   });
 });

--- a/lab-04-redux/src/actions/EmployeeActionCreator.test.js
+++ b/lab-04-redux/src/actions/EmployeeActionCreator.test.js
@@ -1,6 +1,5 @@
-
 describe('employee actions', () => {
-  it('implement me', () =>{
+  it('implement me', () => {
     expect(true).toEqual(true);
   });
 });

--- a/lab-04-redux/src/actions/ProjectActionCreator.js
+++ b/lab-04-redux/src/actions/ProjectActionCreator.js
@@ -1,21 +1,19 @@
 import * as ProjectActionTypes from './ProjectActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/projects';
 
-const url = (projectId) => {
-
+const url = projectId => {
   let url = apiUrl;
   if (projectId) {
     url += '/' + projectId;
   }
 
   return url;
-}
+};
 
 export const listProjects = () => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -25,10 +23,10 @@ export const listProjects = () => {
         console.log('Error attempting to retrieve projects.', error);
       });
   };
-}
+};
 
-export const getProject = (id) => {
-  return (dispatch) => {
+export const getProject = id => {
+  return dispatch => {
     return Axios.get(url(id))
       .then(res => {
         dispatch(get(res.data));
@@ -37,11 +35,11 @@ export const getProject = (id) => {
       .catch(error => {
         console.log('There was an error getting the project');
       });
-  }
-}
+  };
+};
 
-export const updateProject = (project) => {
-  return (dispatch) => {
+export const updateProject = project => {
+  return dispatch => {
     return Axios.put(url(project._id), project)
       .then(res => {
         dispatch(get(res.data));
@@ -51,11 +49,11 @@ export const updateProject = (project) => {
       .catch(error => {
         console.log('There was an error updating project.');
       });
-  }
-}
+  };
+};
 
-export const removeProject = (project) => {
-  return (dispatch) => {
+export const removeProject = project => {
+  return dispatch => {
     project.deleted = true;
 
     return Axios.put(url(project._id), project)
@@ -67,49 +65,49 @@ export const removeProject = (project) => {
       .catch(error => {
         console.log('Error attempting to delete project.');
       });
-  }
-}
+  };
+};
 
-export const restoreProject = (project) => {
-  return (dispatch) => {
+export const restoreProject = project => {
+  return dispatch => {
     project.deleted = false;
 
     return Axios.put(url(project._id), project)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Project : ' + res.data.name + ', was restored.');
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore project.');
       });
-  }
-}
+  };
+};
 
-export const createProject = (project) => {
-  return (dispatch) => {
+export const createProject = project => {
+  return dispatch => {
     return Axios.put(url(), project)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Project : ' + res.data.name + ', created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating project.');
       });
-  }
-}
+  };
+};
 
-export const list = (projects) => {
+export const list = projects => {
   return {
     type: ProjectActionTypes.LIST,
     projects: projects
-  }
-}
+  };
+};
 
-export const get = (project) => {
+export const get = project => {
   return {
     type: ProjectActionTypes.GET,
     project: project
-  }
-}
+  };
+};

--- a/lab-04-redux/src/actions/ProjectActionCreator.test.js
+++ b/lab-04-redux/src/actions/ProjectActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './ProjectActionCreator'
-import * as types from './ProjectActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './ProjectActionCreator';
+import * as types from './ProjectActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        projects: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      projects: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        project: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      project: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching projects has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['project1', 'project2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, projects: ['project1', 'project2']}
-    ]
-    const store = mockStore({projects: []})
+      { type: types.LIST, projects: ['project1', 'project2'] }
+    ];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.listProjects())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listProjects()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single project', () => {
     moxios.stubRequest('/api/projects/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'project1'
     });
 
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
-
-    return store.dispatch(actions.getProject(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getProject(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a project', () => {
     moxios.stubRequest('/api/projects/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.updateProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a project', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.removeProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a project', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.restoreProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/lab-04-redux/src/actions/ProjectActionCreator.test.js
+++ b/lab-04-redux/src/actions/ProjectActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['project1', 'project2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, projects: ['project1', 'project2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, projects: ['project1', 'project2'] }];
     const store = mockStore({ projects: [] });
 
     return store.dispatch(actions.listProjects()).then(() => {

--- a/lab-04-redux/src/actions/ProjectActionTypes.js
+++ b/lab-04-redux/src/actions/ProjectActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_PROJECTS";
-export const GET = "GET_PROJECT";
+export const LIST = 'LIST_PROJECTS';
+export const GET = 'GET_PROJECT';

--- a/lab-04-redux/src/actions/TimesheetActionCreator.js
+++ b/lab-04-redux/src/actions/TimesheetActionCreator.js
@@ -1,21 +1,19 @@
 import * as TimesheetActionTypes from './TimesheetActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/users/all/timesheets';
 
-const url = (timesheetId) => {
-
+const url = timesheetId => {
   let url = apiUrl;
   if (timesheetId) {
     url += '/' + timesheetId;
   }
 
   return url;
-}
+};
 
 export const listTimesheets = () => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -25,10 +23,10 @@ export const listTimesheets = () => {
         console.log('Error attempting to retrieve timesheets.');
       });
   };
-}
+};
 
-export const getTimesheet = (id) => {
-  return (dispatch) => {
+export const getTimesheet = id => {
+  return dispatch => {
     return Axios.get(url(id))
       .then(res => {
         dispatch(get(res.data));
@@ -37,11 +35,11 @@ export const getTimesheet = (id) => {
       .catch(error => {
         console.log('There was an error getting the timesheet');
       });
-  }
-}
+  };
+};
 
-export const updateTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const updateTimesheet = timesheet => {
+  return dispatch => {
     return Axios.put(url(timesheet._id), timesheet)
       .then(res => {
         dispatch(get(res.data));
@@ -51,11 +49,11 @@ export const updateTimesheet = (timesheet) => {
       .catch(error => {
         console.log('There was an error updating timesheet.');
       });
-  }
-}
+  };
+};
 
-export const removeTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const removeTimesheet = timesheet => {
+  return dispatch => {
     timesheet.deleted = true;
 
     return Axios.put(url(timesheet._id), timesheet)
@@ -67,49 +65,49 @@ export const removeTimesheet = (timesheet) => {
       .catch(error => {
         console.log('Error attempting to delete timesheet.');
       });
-  }
-}
+  };
+};
 
-export const restoreTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const restoreTimesheet = timesheet => {
+  return dispatch => {
     timesheet.deleted = false;
 
     return Axios.put(url(timesheet._id), timesheet)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timesheet : ' + res.data.name + ', was restored.');
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore timesheet.');
       });
-  }
-}
+  };
+};
 
-export const createTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const createTimesheet = timesheet => {
+  return dispatch => {
     return Axios.put(url(), timesheet)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timesheet : ' + res.data.name + ', created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating timesheet.');
       });
-  }
-}
+  };
+};
 
-export const list = (timesheets) => {
+export const list = timesheets => {
   return {
     type: TimesheetActionTypes.LIST,
     timesheets: timesheets
-  }
-}
+  };
+};
 
-export const get = (timesheet) => {
+export const get = timesheet => {
   return {
     type: TimesheetActionTypes.GET,
     timesheet: timesheet
-  }
-}
+  };
+};

--- a/lab-04-redux/src/actions/TimesheetActionCreator.test.js
+++ b/lab-04-redux/src/actions/TimesheetActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './TimesheetActionCreator'
-import * as types from './TimesheetActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './TimesheetActionCreator';
+import * as types from './TimesheetActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        timesheets: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      timesheets: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        timesheet: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      timesheet: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching timesheets has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['timesheet1', 'timesheet2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, timesheets: ['timesheet1', 'timesheet2']}
-    ]
-    const store = mockStore({timesheets: []})
+      { type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }
+    ];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.listTimesheets())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listTimesheets()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single timesheet', () => {
     moxios.stubRequest('/api/users/all/timesheets/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
-
-    return store.dispatch(actions.getTimesheet(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getTimesheet(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a timesheet', () => {
     moxios.stubRequest('/api/users/all/timesheets/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.updateTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a timesheet', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.removeTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a timesheet', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.restoreTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/lab-04-redux/src/actions/TimesheetActionCreator.test.js
+++ b/lab-04-redux/src/actions/TimesheetActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['timesheet1', 'timesheet2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }];
     const store = mockStore({ timesheets: [] });
 
     return store.dispatch(actions.listTimesheets()).then(() => {

--- a/lab-04-redux/src/actions/TimesheetActionTypes.js
+++ b/lab-04-redux/src/actions/TimesheetActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_TIMESHEETS";
-export const GET = "GET_TIMESHEET";
+export const LIST = 'LIST_TIMESHEETS';
+export const GET = 'GET_TIMESHEET';

--- a/lab-04-redux/src/components/employees/EmployeeRow.js
+++ b/lab-04-redux/src/components/employees/EmployeeRow.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class EmployeeRow extends Component {
-
   render() {
     const employee = this.props.employee;
 
@@ -16,7 +15,6 @@ class EmployeeRow extends Component {
       </tr>
     );
   }
-
 }
 
 EmployeeRow.propTypes = {

--- a/lab-04-redux/src/components/employees/EmployeeRow.test.js
+++ b/lab-04-redux/src/components/employees/EmployeeRow.test.js
@@ -2,26 +2,20 @@ import React from 'react';
 import EmployeeRow from './EmployeeRow';
 import { shallow } from 'enzyme';
 
-describe('Employee Row Component: ', () =>  {
+describe('Employee Row Component: ', () => {
+  it('should instantiate the Employee Row Component', () => {
+    const employee = {
+      username: 'fflintstone',
+      email: 'fred.flintstone@slatequarry.com',
+      firstName: 'Fred',
+      lastName: 'Flintstone',
+      admin: true
+    };
 
+    const component = shallow(<EmployeeRow employee={employee} />);
 
-    it('should instantiate the Employee Row Component', () =>  {
-
-        const employee = {username:'fflintstone',
-                          'email':'fred.flintstone@slatequarry.com',
-                          'firstName':'Fred',
-                          'lastName':'Flintstone',
-                          'admin':true
-                         }
-
-        const component = shallow(
-                <EmployeeRow employee={employee}/>
-        );
-
-        expect(component).toContainReact(<td>Flintstone</td>);
-        expect(component).toContainReact(<td>fflintstone</td>);
-        expect(component).toContainReact(<td>Yes</td>);
-
-    });
-
+    expect(component).toContainReact(<td>Flintstone</td>);
+    expect(component).toContainReact(<td>fflintstone</td>);
+    expect(component).toContainReact(<td>Yes</td>);
+  });
 });

--- a/lab-04-redux/src/components/employees/EmployeeTable.js
+++ b/lab-04-redux/src/components/employees/EmployeeTable.js
@@ -2,31 +2,26 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import EmployeeRow from './EmployeeRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class EmployeeTable extends Component {
   render() {
-
     let employeeRows = this.props.employees.map(employee => {
-      return (
-        <EmployeeRow employee={employee} key={employee._id} />
-      );
+      return <EmployeeRow employee={employee} key={employee._id} />;
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Username</th>
-          <th>Email</th>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>Admin</th>
-        </tr>
+          <tr>
+            <th>Username</th>
+            <th>Email</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Admin</th>
+          </tr>
         </thead>
-        <tbody>
-          {employeeRows}
-        </tbody>
+        <tbody>{employeeRows}</tbody>
       </Table>
     );
   }

--- a/lab-04-redux/src/components/employees/EmployeeTable.test.js
+++ b/lab-04-redux/src/components/employees/EmployeeTable.test.js
@@ -2,31 +2,24 @@ import React from 'react';
 import EmployeeTable from './EmployeeTable';
 import { mount } from 'enzyme';
 
-describe('Employee Table Component: ', () =>  {
+describe('Employee Table Component: ', () => {
+  it('should instantiate the Employee Table', () => {
+    const employees = [
+      {
+        username: 'fflintstone',
+        email: 'fred.flintstone@slatequarry.com',
+        firstName: 'Fred',
+        lastName: 'Flintstone',
+        admin: true,
+        _id: 1
+      }
+    ];
 
+    const component = mount(<EmployeeTable employees={employees} />);
 
-    it('should instantiate the Employee Table', () =>  {
+    expect(component).toContainReact(<th>Last Name</th>);
+    expect(component).toIncludeText('Flintstone');
 
-
-        const employees = [{username:'fflintstone',
-                          'email':'fred.flintstone@slatequarry.com',
-                          'firstName':'Fred',
-                          'lastName':'Flintstone',
-                          'admin':true,
-                          '_id':1
-                         }]
-
-
-
-        const component = mount(
-                <EmployeeTable employees={employees}/>
-        );
-
-        expect(component).toContainReact(<th>Last Name</th>);
-        expect(component).toIncludeText('Flintstone');
-
-        expect(component.find('tbody tr')).toHaveLength(1);
-
+    expect(component.find('tbody tr')).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/employees/Employees.js
+++ b/lab-04-redux/src/components/employees/Employees.js
@@ -1,31 +1,30 @@
 import React, { Component } from 'react';
 import EmployeeTable from './EmployeeTable';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 
 class Employees extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
       pageConfig: {
         data: [
           {
-            "_id": 1,
-            "username": "admin",
-            "email": "admin@mixtape.com",
-            "password": "password",
-            "admin": true,
-            "firstName": "Admin",
-            "lastName": "User"
+            _id: 1,
+            username: 'admin',
+            email: 'admin@mixtape.com',
+            password: 'password',
+            admin: true,
+            firstName: 'Admin',
+            lastName: 'User'
           },
           {
-            "_id": 2,
-            "username": "user",
-            "email": "user@mixtape.com",
-            "password": "password",
-            "admin": false,
-            "firstName": "Normal",
-            "lastName": "User"
+            _id: 2,
+            username: 'user',
+            email: 'user@mixtape.com',
+            password: 'password',
+            admin: false,
+            firstName: 'Normal',
+            lastName: 'User'
           }
         ]
       }
@@ -39,7 +38,7 @@ class Employees extends Component {
           <PageHeader>Employees</PageHeader>
         </Row>
         <Row>
-          <EmployeeTable employees={this.state.pageConfig.data}/>
+          <EmployeeTable employees={this.state.pageConfig.data} />
         </Row>
       </Grid>
     );

--- a/lab-04-redux/src/components/employees/Employees.test.js
+++ b/lab-04-redux/src/components/employees/Employees.test.js
@@ -5,15 +5,10 @@ import configureStore from '../../store/configure-store';
 
 const mockStore = configureStore();
 
-describe('Employees Component: ', () =>  {
+describe('Employees Component: ', () => {
+  it('should instantiate the Employee Component', () => {
+    const component = shallow(<Employees store={mockStore} />);
 
-  it('should instantiate the Employee Component', () =>  {
-      const component = shallow(
-              <Employees store={mockStore}/>
-      );
-
-      expect(component).toHaveLength(1);
-
+    expect(component).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/nav/Navigation.js
+++ b/lab-04-redux/src/components/nav/Navigation.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
-import {Navbar, Nav, NavItem} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Navbar, Nav, NavItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class NavBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      user: {_id: 'all'}
+      user: { _id: 'all' }
     };
   }
 
@@ -14,9 +14,7 @@ class NavBar extends Component {
     return (
       <Navbar>
         <Navbar.Header>
-          <Navbar.Brand>
-            Timesheetz
-          </Navbar.Brand>
+          <Navbar.Brand>Timesheetz</Navbar.Brand>
         </Navbar.Header>
         <Nav>
           <LinkContainer to="/projects">

--- a/lab-04-redux/src/components/nav/Navigation.test.js
+++ b/lab-04-redux/src/components/nav/Navigation.test.js
@@ -3,18 +3,20 @@ import { mount } from 'enzyme';
 
 import Navigation from './Navigation';
 
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
-describe('Navigation Component: ', () =>  {
-
+describe('Navigation Component: ', () => {
   let nav;
 
-  beforeEach(() =>{
-    nav = mount(<BrowserRouter><Navigation /></BrowserRouter>);
+  beforeEach(() => {
+    nav = mount(
+      <BrowserRouter>
+        <Navigation />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Navigation Component', () =>  {
+  it('should instantiate the Navigation Component', () => {
     expect(nav).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/projects/ProjectRow.js
+++ b/lab-04-redux/src/components/projects/ProjectRow.js
@@ -1,33 +1,38 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 class ProjectRow extends Component {
-
   handleClick(project) {
-    if(project.deleted){
+    if (project.deleted) {
       project.deleted = false;
-      this.props.actions.restoreProject(project).then(this.props.actions.listProjects);
-    }
-    else{
+      this.props.actions
+        .restoreProject(project)
+        .then(this.props.actions.listProjects);
+    } else {
       project.deleted = true;
-      this.props.actions.removeProject(project).then(this.props.actions.listProjects);
+      this.props.actions
+        .removeProject(project)
+        .then(this.props.actions.listProjects);
     }
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.project.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.project.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={() => {this.handleClick(this.props.project)}}
+        onClick={() => {
+          this.handleClick(this.props.project);
+        }}
         bsStyle={this.props.project.deleted ? 'success' : 'danger'}
       >
         {this.props.project.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
       <tr className={rowClass}>

--- a/lab-04-redux/src/components/projects/ProjectRow.js
+++ b/lab-04-redux/src/components/projects/ProjectRow.js
@@ -6,14 +6,10 @@ class ProjectRow extends Component {
   handleClick(project) {
     if (project.deleted) {
       project.deleted = false;
-      this.props.actions
-        .restoreProject(project)
-        .then(this.props.actions.listProjects);
+      this.props.actions.restoreProject(project).then(this.props.actions.listProjects);
     } else {
       project.deleted = true;
-      this.props.actions
-        .removeProject(project)
-        .then(this.props.actions.listProjects);
+      this.props.actions.removeProject(project).then(this.props.actions.listProjects);
     }
   }
 

--- a/lab-04-redux/src/components/projects/ProjectRow.test.js
+++ b/lab-04-redux/src/components/projects/ProjectRow.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import ProjectRow from './ProjectRow';
 
-describe('Project Row Component: ', () =>  {
-
+describe('Project Row Component: ', () => {
   let projectRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const project = {};
     projectRow = shallow(<ProjectRow project={project} />);
   });
 
-  it('should instantiate the Project Row Component', () =>  {
+  it('should instantiate the Project Row Component', () => {
     expect(projectRow).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/projects/ProjectTable.js
+++ b/lab-04-redux/src/components/projects/ProjectTable.js
@@ -2,31 +2,28 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectRow from './ProjectRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class ProjectTable extends Component {
   render() {
-
     const actions = this.props.actions;
 
     const projectRows = this.props.projects.map(project => {
       return (
-        <ProjectRow project={project} key={project._id} actions={actions}/>
+        <ProjectRow project={project} key={project._id} actions={actions} />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {projectRows}
-        </tbody>
+        <tbody>{projectRows}</tbody>
       </Table>
     );
   }

--- a/lab-04-redux/src/components/projects/ProjectTable.js
+++ b/lab-04-redux/src/components/projects/ProjectTable.js
@@ -9,9 +9,7 @@ class ProjectTable extends Component {
     const actions = this.props.actions;
 
     const projectRows = this.props.projects.map(project => {
-      return (
-        <ProjectRow project={project} key={project._id} actions={actions} />
-      );
+      return <ProjectRow project={project} key={project._id} actions={actions} />;
     });
 
     return (

--- a/lab-04-redux/src/components/projects/ProjectTable.test.js
+++ b/lab-04-redux/src/components/projects/ProjectTable.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import ProjectTable from './ProjectTable';
 
-describe('Project Table Component: ', () =>  {
-
+describe('Project Table Component: ', () => {
   let projectTable;
 
-  beforeEach(() =>{
-    const projects = [{_id: 1}, {_id: 2}];
+  beforeEach(() => {
+    const projects = [{ _id: 1 }, { _id: 2 }];
     projectTable = shallow(<ProjectTable projects={projects} />);
   });
 
-  it('should instantiate the Project Table Component', () =>  {
+  it('should instantiate the Project Table Component', () => {
     expect(projectTable).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/projects/Projects.js
+++ b/lab-04-redux/src/components/projects/Projects.js
@@ -19,10 +19,7 @@ class Projects extends Component {
           <PageHeader>Projects</PageHeader>
         </Row>
         <Row>
-          <ProjectTable
-            projects={this.props.projects}
-            actions={this.props.actions}
-          />
+          <ProjectTable projects={this.props.projects} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/lab-04-redux/src/components/projects/Projects.js
+++ b/lab-04-redux/src/components/projects/Projects.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 
 import ProjectTable from './ProjectTable';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
 class Projects extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listProjects();
@@ -20,27 +19,26 @@ class Projects extends Component {
           <PageHeader>Projects</PageHeader>
         </Row>
         <Row>
-          <ProjectTable projects={this.props.projects} actions={this.props.actions}/>
+          <ProjectTable
+            projects={this.props.projects}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     projects: state.projects.projects
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Projects);
+export default connect(mapStateToProps, mapDispatchToProps)(Projects);

--- a/lab-04-redux/src/components/projects/Projects.test.js
+++ b/lab-04-redux/src/components/projects/Projects.test.js
@@ -4,17 +4,15 @@ import { shallow } from 'enzyme';
 import Projects from './Projects';
 import configureStore from '../../store/configure-store';
 
-describe('Projects Component: ', () =>  {
-
+describe('Projects Component: ', () => {
   let projects;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    projects = shallow(<Projects store={mockStore}/>);
+  beforeEach(() => {
+    projects = shallow(<Projects store={mockStore} />);
   });
 
-  it('should instantiate the Project Component', () =>  {
+  it('should instantiate the Project Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/timesheets/TimesheetRow.js
+++ b/lab-04-redux/src/components/timesheets/TimesheetRow.js
@@ -1,34 +1,39 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 
 class TimesheetRow extends Component {
-
   handleClick(timesheet) {
-    if(timesheet.deleted){
+    if (timesheet.deleted) {
       timesheet.deleted = false;
-      this.props.actions.restoreTimesheet(timesheet).then(this.props.actions.listTimesheets);
-    }
-    else{
+      this.props.actions
+        .restoreTimesheet(timesheet)
+        .then(this.props.actions.listTimesheets);
+    } else {
       timesheet.deleted = true;
-      this.props.actions.removeTimesheet(timesheet).then(this.props.actions.listTimesheets);
+      this.props.actions
+        .removeTimesheet(timesheet)
+        .then(this.props.actions.listTimesheets);
     }
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.timesheet.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.timesheet.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={() => {this.handleClick(this.props.timesheet)}}
+        onClick={() => {
+          this.handleClick(this.props.timesheet);
+        }}
         bsStyle={this.props.timesheet.deleted ? 'success' : 'danger'}
       >
         {this.props.timesheet.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
       <tr className={rowClass}>

--- a/lab-04-redux/src/components/timesheets/TimesheetRow.js
+++ b/lab-04-redux/src/components/timesheets/TimesheetRow.js
@@ -7,14 +7,10 @@ class TimesheetRow extends Component {
   handleClick(timesheet) {
     if (timesheet.deleted) {
       timesheet.deleted = false;
-      this.props.actions
-        .restoreTimesheet(timesheet)
-        .then(this.props.actions.listTimesheets);
+      this.props.actions.restoreTimesheet(timesheet).then(this.props.actions.listTimesheets);
     } else {
       timesheet.deleted = true;
-      this.props.actions
-        .removeTimesheet(timesheet)
-        .then(this.props.actions.listTimesheets);
+      this.props.actions.removeTimesheet(timesheet).then(this.props.actions.listTimesheets);
     }
   }
 

--- a/lab-04-redux/src/components/timesheets/TimesheetRow.test.js
+++ b/lab-04-redux/src/components/timesheets/TimesheetRow.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import TimesheetRow from './TimesheetRow';
 
-describe('Timesheet Row Component: ', () =>  {
-
+describe('Timesheet Row Component: ', () => {
   let timesheetRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const timesheet = {};
     timesheetRow = shallow(<TimesheetRow timesheet={timesheet} />);
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheetRow).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/timesheets/TimesheetTable.js
+++ b/lab-04-redux/src/components/timesheets/TimesheetTable.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimesheetRow from './TimesheetRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class TimesheetTable extends Component {
   render() {
@@ -10,24 +10,26 @@ class TimesheetTable extends Component {
 
     let timesheetRows = this.props.timesheets.map(timesheet => {
       return (
-        <TimesheetRow timesheet={timesheet} key={timesheet._id} actions={actions}/>
+        <TimesheetRow
+          timesheet={timesheet}
+          key={timesheet._id}
+          actions={actions}
+        />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Begin Date</th>
-          <th>End Date</th>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Begin Date</th>
+            <th>End Date</th>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {timesheetRows}
-        </tbody>
+        <tbody>{timesheetRows}</tbody>
       </Table>
     );
   }

--- a/lab-04-redux/src/components/timesheets/TimesheetTable.js
+++ b/lab-04-redux/src/components/timesheets/TimesheetTable.js
@@ -9,13 +9,7 @@ class TimesheetTable extends Component {
     const actions = this.props.actions;
 
     let timesheetRows = this.props.timesheets.map(timesheet => {
-      return (
-        <TimesheetRow
-          timesheet={timesheet}
-          key={timesheet._id}
-          actions={actions}
-        />
-      );
+      return <TimesheetRow timesheet={timesheet} key={timesheet._id} actions={actions} />;
     });
 
     return (

--- a/lab-04-redux/src/components/timesheets/TimesheetTable.test.js
+++ b/lab-04-redux/src/components/timesheets/TimesheetTable.test.js
@@ -3,17 +3,15 @@ import { shallow } from 'enzyme';
 
 import TimesheetTable from './TimesheetTable';
 
-describe('Timesheet Table Component: ', () =>  {
-
+describe('Timesheet Table Component: ', () => {
   let timesheetTable;
 
-  beforeEach(() =>{
-    const timesheets = [{_id: 1}, {_id: 2}];
+  beforeEach(() => {
+    const timesheets = [{ _id: 1 }, { _id: 2 }];
     timesheetTable = shallow(<TimesheetTable timesheets={timesheets} />);
   });
 
-  it('should instantiate the Timesheet Table Component', () =>  {
+  it('should instantiate the Timesheet Table Component', () => {
     expect(timesheetTable).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/components/timesheets/Timesheets.js
+++ b/lab-04-redux/src/components/timesheets/Timesheets.js
@@ -1,13 +1,11 @@
 import React, { Component } from 'react';
 import TimesheetTable from './TimesheetTable';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimesheetActions from '../../actions/TimesheetActionCreator';
 
-
 class Timesheets extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listTimesheets();
@@ -20,27 +18,26 @@ class Timesheets extends Component {
           <PageHeader>Timesheets</PageHeader>
         </Row>
         <Row>
-          <TimesheetTable timesheets={this.props.timesheets} actions={this.props.actions}/>
+          <TimesheetTable
+            timesheets={this.props.timesheets}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timesheets: state.timesheets.timesheets
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimesheetActions, dispatch)
   };
-}
+};
 
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Timesheets);
+export default connect(mapStateToProps, mapDispatchToProps)(Timesheets);

--- a/lab-04-redux/src/components/timesheets/Timesheets.js
+++ b/lab-04-redux/src/components/timesheets/Timesheets.js
@@ -18,10 +18,7 @@ class Timesheets extends Component {
           <PageHeader>Timesheets</PageHeader>
         </Row>
         <Row>
-          <TimesheetTable
-            timesheets={this.props.timesheets}
-            actions={this.props.actions}
-          />
+          <TimesheetTable timesheets={this.props.timesheets} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/lab-04-redux/src/components/timesheets/Timesheets.test.js
+++ b/lab-04-redux/src/components/timesheets/Timesheets.test.js
@@ -4,18 +4,15 @@ import { shallow } from 'enzyme';
 import Timesheets from './Timesheets';
 import configureStore from '../../store/configure-store';
 
-
-describe('Timesheets Component: ', () =>  {
-
+describe('Timesheets Component: ', () => {
   let timesheets;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    timesheets = shallow(<Timesheets store={mockStore}/>);
+  beforeEach(() => {
+    timesheets = shallow(<Timesheets store={mockStore} />);
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheets).toHaveLength(1);
   });
-
 });

--- a/lab-04-redux/src/hello/Hello.js
+++ b/lab-04-redux/src/hello/Hello.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 
 class Hello extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -14,7 +13,7 @@ class Hello extends Component {
       <div className="hello">
         <h1>{this.state.greeting}</h1>
         <h2>{this.props.friend}</h2>
-        <p>Congratulations!  You have created your first React component!</p>
+        <p>Congratulations! You have created your first React component!</p>
       </div>
     );
   }

--- a/lab-04-redux/src/hello/Hello.test.js
+++ b/lab-04-redux/src/hello/Hello.test.js
@@ -4,13 +4,12 @@ import renderer from 'react-test-renderer';
 
 import Hello from './Hello';
 
-describe('Hello World:', () =>  {
-
+describe('Hello World:', () => {
   it('renders without exploding', () => {
     expect(shallow(<Hello />)).toHaveLength(1);
   });
 
-  it('should render with default text', () =>  {
+  it('should render with default text', () => {
     const component = shallow(<Hello />);
 
     expect(component).toIncludeText('Howdy');
@@ -19,10 +18,8 @@ describe('Hello World:', () =>  {
     expect(component).toHaveState('greeting', 'Howdy!!');
   });
 
-  it('should render with our props', () =>  {
-    const component = shallow(
-      <Hello friend="Fred"/>
-    );
+  it('should render with our props', () => {
+    const component = shallow(<Hello friend="Fred" />);
 
     expect(component).toIncludeText('Howdy');
 
@@ -30,12 +27,9 @@ describe('Hello World:', () =>  {
     expect(component).not.toIncludeText('Partner');
   });
 
-  it('should render to match the snapshot', () =>  {
-    const component = renderer.create(
-      <Hello friend="Luke"/>
-    );
+  it('should render to match the snapshot', () => {
+    const component = renderer.create(<Hello friend="Luke" />);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
-
 });

--- a/lab-04-redux/src/reducers/index.js
+++ b/lab-04-redux/src/reducers/index.js
@@ -1,4 +1,4 @@
-import {combineReducers} from "redux";
+import { combineReducers } from 'redux';
 import projects from './project-reducer';
 import timesheets from './timesheet-reducer';
 

--- a/lab-04-redux/src/reducers/project-reducer.js
+++ b/lab-04-redux/src/reducers/project-reducer.js
@@ -1,13 +1,13 @@
 import * as ProjectActionTypes from '../actions/ProjectActionTypes';
 
-export default (state = {projects: [], project: {}}, action) => {
+export default (state = { projects: [], project: {} }, action) => {
   switch (action.type) {
     case ProjectActionTypes.LIST:
-      return Object.assign({}, state, {projects: action.projects});
+      return Object.assign({}, state, { projects: action.projects });
     case ProjectActionTypes.GET:
-      return Object.assign({}, state, {project: action.project});
+      return Object.assign({}, state, { project: action.project });
 
     default:
       return state;
   }
-}
+};

--- a/lab-04-redux/src/reducers/timesheet-reducer.js
+++ b/lab-04-redux/src/reducers/timesheet-reducer.js
@@ -1,13 +1,13 @@
 import * as TimesheetActionTypes from '../actions/TimesheetActionTypes';
 
-export default (state = {timesheets: [], timesheet: {}}, action) => {
+export default (state = { timesheets: [], timesheet: {} }, action) => {
   switch (action.type) {
     case TimesheetActionTypes.LIST:
-      return Object.assign({}, state, {timesheets: action.timesheets});
+      return Object.assign({}, state, { timesheets: action.timesheets });
     case TimesheetActionTypes.GET:
-      return Object.assign({}, state, {timesheet: action.timesheet});
+      return Object.assign({}, state, { timesheet: action.timesheet });
 
     default:
       return state;
   }
-}
+};

--- a/lab-04-redux/src/setupTests.js
+++ b/lab-04-redux/src/setupTests.js
@@ -2,9 +2,9 @@
 //See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#initializing-test-environment
 
 import 'jest-enzyme';
-import { configure } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 configure({
   adapter: new Adapter()
-})
+});

--- a/lab-04-redux/src/store/configure-store.js
+++ b/lab-04-redux/src/store/configure-store.js
@@ -1,9 +1,7 @@
 import rootReducer from '../reducers';
-import {createStore, applyMiddleware} from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
-export default (initialState = {projects: []}) => {
-  return createStore(rootReducer, initialState,
-    applyMiddleware(thunk)
-  );
+export default (initialState = { projects: [] }) => {
+  return createStore(rootReducer, initialState, applyMiddleware(thunk));
 };

--- a/lab-05-form-validation/src/App.js
+++ b/lab-05-form-validation/src/App.js
@@ -28,11 +28,7 @@ class App extends Component {
             <Route exact path="/employees" component={Employees} />
             {/* TODO - Add the employee detail and create routes*/}
 
-            <Route
-              exact
-              path="/employees/:user_id/timesheets"
-              component={Timesheets}
-            />
+            <Route exact path="/employees/:user_id/timesheets" component={Timesheets} />
             {/* TODO - Add the timesheets detail and create routes */}
 
             {/* TODO - Add the timeunits detail and create routes*/}

--- a/lab-05-form-validation/src/App.js
+++ b/lab-05-form-validation/src/App.js
@@ -12,30 +12,33 @@ import TimesheetsCreate from './components/timesheets/TimesheetsCreate';
 import TimeunitsCreate from './components/timeunits/TimeunitsCreate';
 import TimeunitsDetail from './components/timeunits/TimeunitsDetail';
 import Navigation from './components/nav/Navigation';
-import {BrowserRouter, Route, Switch, Redirect} from 'react-router-dom';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 
 class App extends Component {
   render() {
     return (
       <BrowserRouter>
         <div className="App">
-          <Navigation/>
-            <Switch>
-              <Route exact path="/projects" component={Projects}/>
-              <Route path='/projects/detail/:_id' component={ProjectsDetail} />
-              <Route path='/projects/create' component={ProjectsCreate} />
+          <Navigation />
+          <Switch>
+            <Route exact path="/projects" component={Projects} />
+            <Route path="/projects/detail/:_id" component={ProjectsDetail} />
+            <Route path="/projects/create" component={ProjectsCreate} />
 
-              <Route exact path="/employees" component={Employees}/>
-              {/* TODO - Add the employee detail and create routes*/}
+            <Route exact path="/employees" component={Employees} />
+            {/* TODO - Add the employee detail and create routes*/}
 
-              <Route exact path="/employees/:user_id/timesheets" component={Timesheets}/>
-              {/* TODO - Add the timesheets detail and create routes */}
+            <Route
+              exact
+              path="/employees/:user_id/timesheets"
+              component={Timesheets}
+            />
+            {/* TODO - Add the timesheets detail and create routes */}
 
-              {/* TODO - Add the timeunits detail and create routes*/}
+            {/* TODO - Add the timeunits detail and create routes*/}
 
-              <Redirect to="/employees"/>
-            </Switch>
-
+            <Redirect to="/employees" />
+          </Switch>
         </div>
       </BrowserRouter>
     );

--- a/lab-05-form-validation/src/App.test.js
+++ b/lab-05-form-validation/src/App.test.js
@@ -11,9 +11,6 @@ describe('App Component', () => {
   it('renders with our expected text', () => {
     const result = shallow(<App />);
 
-    expect(result.find('Route').at(1)).toHaveProp(
-      'path',
-      '/projects/detail/:_id'
-    );
+    expect(result.find('Route').at(1)).toHaveProp('path', '/projects/detail/:_id');
   });
 });

--- a/lab-05-form-validation/src/App.test.js
+++ b/lab-05-form-validation/src/App.test.js
@@ -9,10 +9,11 @@ describe('App Component', () => {
   });
 
   it('renders with our expected text', () => {
-
     const result = shallow(<App />);
 
-    expect(result.find('Route').at(1)).toHaveProp('path', '/projects/detail/:_id');
-
+    expect(result.find('Route').at(1)).toHaveProp(
+      'path',
+      '/projects/detail/:_id'
+    );
   });
 });

--- a/lab-05-form-validation/src/actions/EmployeeActionCreator.js
+++ b/lab-05-form-validation/src/actions/EmployeeActionCreator.js
@@ -1,35 +1,33 @@
 import * as EmployeeActionTypes from './EmployeeActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/users';
 
-const url = (employeeId) => {
-
+const url = employeeId => {
   let url = apiUrl;
   if (employeeId) {
     url += '/' + employeeId;
   }
 
   return url;
-}
+};
 
-export const list = (employees) => {
+export const list = employees => {
   return {
     type: EmployeeActionTypes.LIST,
     employees: employees
-  }
-}
+  };
+};
 
-export const get = (employee) => {
+export const get = employee => {
   return {
     type: EmployeeActionTypes.GET,
     employee: employee
-  }
-}
+  };
+};
 
 export const listEmployees = () => {
-  return dispatch =>  {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -39,78 +37,77 @@ export const listEmployees = () => {
         console.log('Error attempting to retrieve employees.', error);
       });
   };
-}
+};
 
-export const getEmployee = (id) => {
-  return (dispatch) => {
+export const getEmployee = id => {
+  return dispatch => {
     return Axios.get(url(id))
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('There was an error getting the employee');
       });
-  }
-}
+  };
+};
 
-export const updateEmployee = (employee) => {
-  return (dispatch) => {
+export const updateEmployee = employee => {
+  return dispatch => {
     return Axios.put(url(employee._id), employee)
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         console.log('Employee : ' + employee.name + ', updated.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('There was an error updating employee.');
       });
-  }
-}
+  };
+};
 
-export const removeEmployee = (employee) => {
-  return (dispatch) => {
+export const removeEmployee = employee => {
+  return dispatch => {
     employee.deleted = true;
 
     return Axios.put(url(employee._id), employee)
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         console.log('Employee : ' + res.data.name + ', was deleted.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('Error attempting to delete employee.');
       });
-  }
-}
+  };
+};
 
-export const restoreEmployee = (employee) => {
-  return (dispatch) => {
+export const restoreEmployee = employee => {
+  return dispatch => {
     employee.deleted = false;
 
     return Axios.put(url(employee._id), employee)
-      .then(res =>  {
-        dispatch(get(res.data))
+      .then(res => {
+        dispatch(get(res.data));
         console.log('Employee : ' + res.data.name + ', was restored.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('Error attempting to restore employee.');
       });
-  }
-}
+  };
+};
 
-export const createEmployee = (employee) => {
-  return (dispatch) => {
+export const createEmployee = employee => {
+  return dispatch => {
     return Axios.post(url(), employee)
-      .then(res =>  {
-        dispatch(get(res.data))
+      .then(res => {
+        dispatch(get(res.data));
         console.log('Employee : ' + res.data.name + ', created.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('There was an error creating employee.');
       });
-  }
-}
-
+  };
+};

--- a/lab-05-form-validation/src/actions/EmployeeActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/EmployeeActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './EmployeeActionCreator'
-import * as types from './EmployeeActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './EmployeeActionCreator';
+import * as types from './EmployeeActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        employees: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      employees: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        employee: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      employee: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching employees has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['employee1', 'employee2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, employees: ['employee1', 'employee2']}
-    ]
-    const store = mockStore({employees: []})
+      { type: types.LIST, employees: ['employee1', 'employee2'] }
+    ];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.listEmployees())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listEmployees()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single employee', () => {
     moxios.stubRequest('/api/users/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
-
-    return store.dispatch(actions.getEmployee(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getEmployee(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a employee', () => {
     moxios.stubRequest('/api/users/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.updateEmployee({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateEmployee({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a employee', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.removeEmployee({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeEmployee({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a employee', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'employee1'
     });
 
-    const expectedActions = [
-      {type: types.GET, employee: 'employee1'}
-    ]
-    const store = mockStore({employees: []})
+    const expectedActions = [{ type: types.GET, employee: 'employee1' }];
+    const store = mockStore({ employees: [] });
 
-    return store.dispatch(actions.restoreEmployee({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreEmployee({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/lab-05-form-validation/src/actions/EmployeeActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/EmployeeActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['employee1', 'employee2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, employees: ['employee1', 'employee2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, employees: ['employee1', 'employee2'] }];
     const store = mockStore({ employees: [] });
 
     return store.dispatch(actions.listEmployees()).then(() => {

--- a/lab-05-form-validation/src/actions/EmployeeActionTypes.js
+++ b/lab-05-form-validation/src/actions/EmployeeActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_EMPLOYEES";
-export const GET = "GET_EMPLOYEE";
+export const LIST = 'LIST_EMPLOYEES';
+export const GET = 'GET_EMPLOYEE';

--- a/lab-05-form-validation/src/actions/ProjectActionCreator.js
+++ b/lab-05-form-validation/src/actions/ProjectActionCreator.js
@@ -1,21 +1,19 @@
 import * as ProjectActionTypes from './ProjectActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/projects';
 
-const url = (projectId) => {
-
+const url = projectId => {
   let url = apiUrl;
   if (projectId) {
     url += '/' + projectId;
   }
 
   return url;
-}
+};
 
 export const listProjects = () => {
-  return dispatch =>  {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -25,91 +23,91 @@ export const listProjects = () => {
         console.log('Error attempting to retrieve projects.', error);
       });
   };
-}
+};
 
-export const getProject = (id) => {
-  return (dispatch) => {
+export const getProject = id => {
+  return dispatch => {
     return Axios.get(url(id))
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('There was an error getting the project');
       });
-  }
-}
+  };
+};
 
-export const updateProject = (project) => {
-  return (dispatch) => {
+export const updateProject = project => {
+  return dispatch => {
     return Axios.put(url(project._id), project)
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         console.log('Project : ' + project.name + ', updated.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('There was an error updating project.');
       });
-  }
-}
+  };
+};
 
-export const removeProject = (project) => {
-  return (dispatch) => {
+export const removeProject = project => {
+  return dispatch => {
     project.deleted = true;
 
     return Axios.put(url(project._id), project)
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         console.log('Project : ' + res.data.name + ', was deleted.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('Error attempting to delete project.');
       });
-  }
-}
+  };
+};
 
-export const restoreProject = (project) => {
-  return (dispatch) => {
+export const restoreProject = project => {
+  return dispatch => {
     project.deleted = false;
 
     return Axios.put(url(project._id), project)
-      .then(res =>  {
-        dispatch(get(res.data))
+      .then(res => {
+        dispatch(get(res.data));
         console.log('Project : ' + res.data.name + ', was restored.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('Error attempting to restore project.');
       });
-  }
-}
+  };
+};
 
-export const createProject = (project) => {
-  return (dispatch) => {
+export const createProject = project => {
+  return dispatch => {
     return Axios.post(url(), project)
-      .then(res =>  {
-        dispatch(get(res.data))
+      .then(res => {
+        dispatch(get(res.data));
         console.log('Project : ' + res.data.name + ', created.');
         return true;
       })
-      .catch(x =>  {
+      .catch(x => {
         console.log('There was an error creating project.');
       });
-  }
-}
+  };
+};
 
-export const list = (projects) => {
+export const list = projects => {
   return {
     type: ProjectActionTypes.LIST,
     projects: projects
-  }
-}
+  };
+};
 
-export const get = (project) => {
+export const get = project => {
   return {
     type: ProjectActionTypes.GET,
     project: project
-  }
-}
+  };
+};

--- a/lab-05-form-validation/src/actions/ProjectActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/ProjectActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './ProjectActionCreator'
-import * as types from './ProjectActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './ProjectActionCreator';
+import * as types from './ProjectActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        projects: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      projects: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        project: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      project: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching projects has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['project1', 'project2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, projects: ['project1', 'project2']}
-    ]
-    const store = mockStore({projects: []})
+      { type: types.LIST, projects: ['project1', 'project2'] }
+    ];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.listProjects())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listProjects()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single project', () => {
     moxios.stubRequest('/api/projects/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'project1'
     });
 
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
-
-    return store.dispatch(actions.getProject(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getProject(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a project', () => {
     moxios.stubRequest('/api/projects/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.updateProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a project', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.removeProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a project', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'project1'
     });
 
-    const expectedActions = [
-      {type: types.GET, project: 'project1'}
-    ]
-    const store = mockStore({projects: []})
+    const expectedActions = [{ type: types.GET, project: 'project1' }];
+    const store = mockStore({ projects: [] });
 
-    return store.dispatch(actions.restoreProject({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreProject({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/lab-05-form-validation/src/actions/ProjectActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/ProjectActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['project1', 'project2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, projects: ['project1', 'project2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, projects: ['project1', 'project2'] }];
     const store = mockStore({ projects: [] });
 
     return store.dispatch(actions.listProjects()).then(() => {

--- a/lab-05-form-validation/src/actions/ProjectActionTypes.js
+++ b/lab-05-form-validation/src/actions/ProjectActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_PROJECTS";
-export const GET = "GET_PROJECT";
+export const LIST = 'LIST_PROJECTS';
+export const GET = 'GET_PROJECT';

--- a/lab-05-form-validation/src/actions/TimesheetActionCreator.js
+++ b/lab-05-form-validation/src/actions/TimesheetActionCreator.js
@@ -1,16 +1,16 @@
 import * as TimesheetActionTypes from './TimesheetActionTypes';
 import Axios from 'axios';
 
-const url = (timesheetId, userId='all') => {
+const url = (timesheetId, userId = 'all') => {
   const url = `/api/users/${userId}/timesheets`;
   if (timesheetId) {
     return url + '/' + timesheetId;
   }
   return url;
-}
+};
 
 export const listTimesheets = () => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url())
       .then(response => {
         dispatch(list(response.data));
@@ -20,25 +20,25 @@ export const listTimesheets = () => {
         console.log('Error attempting to retrieve timesheets.');
       });
   };
-}
+};
 
 export const getTimesheet = (id, userId) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url(id, userId))
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         return true;
       })
       .catch(error => {
         console.log('There was an error getting the timesheet');
       });
-  }
-}
+  };
+};
 
-export const updateTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const updateTimesheet = timesheet => {
+  return dispatch => {
     return Axios.put(url(timesheet._id), timesheet)
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         console.log('Timesheet : ' + timesheet.name + ', updated.');
         return true;
@@ -46,15 +46,15 @@ export const updateTimesheet = (timesheet) => {
       .catch(error => {
         console.log('There was an error updating timesheet.');
       });
-  }
-}
+  };
+};
 
-export const removeTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const removeTimesheet = timesheet => {
+  return dispatch => {
     timesheet.deleted = true;
 
     return Axios.put(url(timesheet._id), timesheet)
-      .then(res =>  {
+      .then(res => {
         dispatch(get(res.data));
         console.log('Timesheet : ' + res.data.name + ', was deleted.');
         return true;
@@ -62,49 +62,49 @@ export const removeTimesheet = (timesheet) => {
       .catch(error => {
         console.log('Error attempting to delete timesheet.');
       });
-  }
-}
+  };
+};
 
-export const restoreTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const restoreTimesheet = timesheet => {
+  return dispatch => {
     timesheet.deleted = false;
 
     return Axios.put(url(timesheet._id), timesheet)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timesheet : ' + res.data.name + ', was restored.');
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore timesheet.');
       });
-  }
-}
+  };
+};
 
-export const createTimesheet = (timesheet) => {
-  return (dispatch) => {
+export const createTimesheet = timesheet => {
+  return dispatch => {
     return Axios.post(url(), timesheet)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timesheet : ' + res.data.name + ', created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating timesheet.');
       });
-  }
-}
+  };
+};
 
-export const list = (timesheets) => {
+export const list = timesheets => {
   return {
     type: TimesheetActionTypes.LIST,
     timesheets: timesheets
-  }
-}
+  };
+};
 
-export const get = (timesheet) => {
+export const get = timesheet => {
   return {
     type: TimesheetActionTypes.GET,
     timesheet: timesheet
-  }
-}
+  };
+};

--- a/lab-05-form-validation/src/actions/TimesheetActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/TimesheetActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './TimesheetActionCreator'
-import * as types from './TimesheetActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './TimesheetActionCreator';
+import * as types from './TimesheetActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        timesheets: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      timesheets: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        timesheet: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      timesheet: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching timesheets has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['timesheet1', 'timesheet2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, timesheets: ['timesheet1', 'timesheet2']}
-    ]
-    const store = mockStore({timesheets: []})
+      { type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }
+    ];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.listTimesheets())
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listTimesheets()).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single timesheet', () => {
     moxios.stubRequest('/api/users/all/timesheets/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
-
-    return store.dispatch(actions.getTimesheet(1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getTimesheet(1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a timesheet', () => {
     moxios.stubRequest('/api/users/all/timesheets/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.updateTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a timesheet', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.removeTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a timesheet', () => {
@@ -121,15 +100,12 @@ describe('async actions', () => {
       response: 'timesheet1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timesheet: 'timesheet1'}
-    ]
-    const store = mockStore({timesheets: []})
+    const expectedActions = [{ type: types.GET, timesheet: 'timesheet1' }];
+    const store = mockStore({ timesheets: [] });
 
-    return store.dispatch(actions.restoreTimesheet({_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreTimesheet({ _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/lab-05-form-validation/src/actions/TimesheetActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/TimesheetActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['timesheet1', 'timesheet2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, timesheets: ['timesheet1', 'timesheet2'] }];
     const store = mockStore({ timesheets: [] });
 
     return store.dispatch(actions.listTimesheets()).then(() => {

--- a/lab-05-form-validation/src/actions/TimesheetActionTypes.js
+++ b/lab-05-form-validation/src/actions/TimesheetActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_TIMESHEETS";
-export const GET = "GET_TIMESHEET";
+export const LIST = 'LIST_TIMESHEETS';
+export const GET = 'GET_TIMESHEET';

--- a/lab-05-form-validation/src/actions/TimeunitActionCreator.js
+++ b/lab-05-form-validation/src/actions/TimeunitActionCreator.js
@@ -1,21 +1,19 @@
 import * as TimeunitActionTypes from './TimeunitActionTypes';
 import Axios from 'axios';
 
-
 const apiUrl = '/api/users/all/timesheets/';
 
 const url = (timesheetId, timeunitId) => {
-
   let url = apiUrl + timesheetId + '/timeunits';
   if (timeunitId) {
     url += '/' + timeunitId;
   }
 
   return url;
-}
+};
 
-export const listTimeunits = (timesheetId) => {
-  return (dispatch) => {
+export const listTimeunits = timesheetId => {
+  return dispatch => {
     return Axios.get(url(timesheetId))
       .then(response => {
         dispatch(list(response.data));
@@ -25,10 +23,10 @@ export const listTimeunits = (timesheetId) => {
         console.log('Error attempting to retrieve logged hours.');
       });
   };
-}
+};
 
 export const getTimeunit = (timesheetId, timeunitId) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.get(url(timesheetId, timeunitId))
       .then(res => {
         dispatch(get(res.data));
@@ -37,11 +35,11 @@ export const getTimeunit = (timesheetId, timeunitId) => {
       .catch(error => {
         console.log('There was an error getting the timeunit');
       });
-  }
-}
+  };
+};
 
 export const updateTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.put(url(timesheetId, timeunit._id), timeunit)
       .then(res => {
         dispatch(get(res.data));
@@ -51,11 +49,11 @@ export const updateTimeunit = (timesheetId, timeunit) => {
       .catch(error => {
         console.log('There was an error updating the timeunit.');
       });
-  }
-}
+  };
+};
 
 export const removeTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     timeunit.deleted = true;
 
     return Axios.put(url(timesheetId, timeunit._id), timeunit)
@@ -67,50 +65,49 @@ export const removeTimeunit = (timesheetId, timeunit) => {
       .catch(error => {
         console.log('Error attempting to delete timeunit.');
       });
-  }
-}
+  };
+};
 
 export const restoreTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     timeunit.deleted = false;
 
     return Axios.put(url(timesheetId, timeunit._id), timeunit)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log(`Timesheet : ${res.data.name}, timeunit was restored.`);
         return true;
       })
       .catch(error => {
         console.log('Error attempting to restore timeunit.');
       });
-  }
-}
+  };
+};
 
 export const createTimeunit = (timesheetId, timeunit) => {
-  return (dispatch) => {
+  return dispatch => {
     return Axios.post(url(timesheetId), timeunit)
       .then(res => {
-        dispatch(get(res.data))
+        dispatch(get(res.data));
         console.log('Timeunit created.');
         return true;
       })
       .catch(error => {
         console.log('There was an error creating timeunit.');
       });
-  }
-}
+  };
+};
 
-export const list = (timeunits) => {
+export const list = timeunits => {
   return {
     type: TimeunitActionTypes.LIST,
     timeunits: timeunits
-  }
-}
+  };
+};
 
-export const get = (timeunit) => {
+export const get = timeunit => {
   return {
     type: TimeunitActionTypes.GET,
     timeunit: timeunit
-  }
-}
-
+  };
+};

--- a/lab-05-form-validation/src/actions/TimeunitActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/TimeunitActionCreator.test.js
@@ -38,9 +38,7 @@ describe('async actions', () => {
       response: ['timeunit1', 'timeunit2']
     });
 
-    const expectedActions = [
-      { type: types.LIST, timeunits: ['timeunit1', 'timeunit2'] }
-    ];
+    const expectedActions = [{ type: types.LIST, timeunits: ['timeunit1', 'timeunit2'] }];
     const store = mockStore({ timeunits: [] });
 
     return store.dispatch(actions.listTimeunits(99)).then(() => {

--- a/lab-05-form-validation/src/actions/TimeunitActionCreator.test.js
+++ b/lab-05-form-validation/src/actions/TimeunitActionCreator.test.js
@@ -1,43 +1,35 @@
-import configureMockStore from 'redux-mock-store'
-import thunk from 'redux-thunk'
-import * as actions from './TimeunitActionCreator'
-import * as types from './TimeunitActionTypes'
-import moxios from 'moxios'
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import * as actions from './TimeunitActionCreator';
+import * as types from './TimeunitActionTypes';
+import moxios from 'moxios';
 
-const middlewares = [ thunk ]
-const mockStore = configureMockStore(middlewares)
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
 
 describe('synchronous actions', () => {
-  it('list should send objects', () =>{
-    expect(
-      actions.list(['p1', 'p2'])
-    ).toEqual(
-      {
-        type: types.LIST,
-        timeunits: ['p1', 'p2']
-      }
-    )
+  it('list should send objects', () => {
+    expect(actions.list(['p1', 'p2'])).toEqual({
+      type: types.LIST,
+      timeunits: ['p1', 'p2']
+    });
   });
 
-  it('get should send object', () =>{
-    expect(
-      actions.get('p1')
-    ).toEqual(
-      {
-        type: types.GET,
-        timeunit: 'p1'
-      }
-    )
+  it('get should send object', () => {
+    expect(actions.get('p1')).toEqual({
+      type: types.GET,
+      timeunit: 'p1'
+    });
   });
 });
 
 describe('async actions', () => {
-  beforeEach(() =>  {
-    moxios.install()
+  beforeEach(() => {
+    moxios.install();
   });
 
-  afterEach(() =>  {
-    moxios.uninstall()
+  afterEach(() => {
+    moxios.uninstall();
   });
 
   it('creates LIST when fetching timeunits has been done', () => {
@@ -46,18 +38,16 @@ describe('async actions', () => {
       response: ['timeunit1', 'timeunit2']
     });
 
-
     const expectedActions = [
-      {type: types.LIST, timeunits: ['timeunit1', 'timeunit2']}
-    ]
-    const store = mockStore({timeunits: []})
+      { type: types.LIST, timeunits: ['timeunit1', 'timeunit2'] }
+    ];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.listTimeunits(99))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
+    return store.dispatch(actions.listTimeunits(99)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when requesting single timeunit', () => {
     moxios.stubRequest('/api/users/all/timesheets/99/timeunits/1', {
@@ -65,19 +55,14 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
-
-    return store.dispatch(actions.getTimeunit(99, 1))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.getTimeunit(99, 1)).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
-
 
   it('create GET when updating a timeunit', () => {
     moxios.stubRequest('/api/users/all/timesheets/99/timeunits/1', {
@@ -85,16 +70,13 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.updateTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.updateTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when removing a timeunit', () => {
@@ -103,16 +85,13 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.removeTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.removeTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when restoring a timeunit', () => {
@@ -121,16 +100,13 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.restoreTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.restoreTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 
   it('create GET when posting a new timeunit', () => {
@@ -139,15 +115,12 @@ describe('async actions', () => {
       response: 'timeunit1'
     });
 
-    const expectedActions = [
-      {type: types.GET, timeunit: 'timeunit1'}
-    ]
-    const store = mockStore({timeunits: []})
+    const expectedActions = [{ type: types.GET, timeunit: 'timeunit1' }];
+    const store = mockStore({ timeunits: [] });
 
-    return store.dispatch(actions.createTimeunit(99, {_id: 1}))
-      .then(() => { // return of async actions
-        expect(store.getActions()).toEqual(expectedActions)
-      })
-
+    return store.dispatch(actions.createTimeunit(99, { _id: 1 })).then(() => {
+      // return of async actions
+      expect(store.getActions()).toEqual(expectedActions);
+    });
   });
 });

--- a/lab-05-form-validation/src/actions/TimeunitActionTypes.js
+++ b/lab-05-form-validation/src/actions/TimeunitActionTypes.js
@@ -1,2 +1,2 @@
-export const LIST = "LIST_TIMEUNITS";
-export const GET = "GET_TIMEUNIT";
+export const LIST = 'LIST_TIMEUNITS';
+export const GET = 'GET_TIMEUNIT';

--- a/lab-05-form-validation/src/components/employees/EmployeeForm.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeForm.js
@@ -1,38 +1,49 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl, ButtonGroup} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import {
+  Button,
+  FormGroup,
+  ControlLabel,
+  FormControl,
+  ButtonGroup
+} from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { withRouter } from 'react-router';
 
 class EmployeeForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     //This is the form initial state
     this.state = {
-      username: {value: null, valid: null},
-      email: {value: null, valid: null},
-      firstName: {value: null, valid: null},
-      lastName: {value: null, valid: null},
-      admin: {value: false, valid: null}
+      username: { value: null, valid: null },
+      email: { value: null, valid: null },
+      firstName: { value: null, valid: null },
+      lastName: { value: null, valid: null },
+      admin: { value: false, valid: null }
     };
 
     this.handleUsernameChange = this.handleUsernameChange.bind(this);
-    this.getUsernameValidationState = this.getUsernameValidationState.bind(this);
+    this.getUsernameValidationState = this.getUsernameValidationState.bind(
+      this
+    );
 
     this.handleEmailChange = this.handleEmailChange.bind(this);
     this.getEmailValidationState = this.getEmailValidationState.bind(this);
 
     this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
-    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(this);
+    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(
+      this
+    );
 
     this.handleLastNameChange = this.handleLastNameChange.bind(this);
-    this.getLastNameValidationState = this.getLastNameValidationState.bind(this);
+    this.getLastNameValidationState = this.getLastNameValidationState.bind(
+      this
+    );
 
     this.handleAdminChange = this.handleAdminChange.bind(this);
     this.getAdminValidationState = this.getAdminValidationState.bind(this);
-
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -43,7 +54,7 @@ class EmployeeForm extends Component {
     // TODO - implement me to handle changes from form field props
   }
 
-  handleSave(){
+  handleSave() {
     //TODO: implement handleSave() method here
   }
 
@@ -55,12 +66,11 @@ class EmployeeForm extends Component {
 
   handleAdminChange(value) {
     let isValid = false;
-    if(value !== null){
+    if (value !== null) {
       isValid = true;
     }
-    return this.setState({ admin: {value: value, valid: isValid }});
+    return this.setState({ admin: { value: value, valid: isValid } });
   }
-
 
   getUsernameValidationState() {
     if (!this.state) return;
@@ -70,12 +80,11 @@ class EmployeeForm extends Component {
 
   handleUsernameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ username: {value: value, valid: isValid }});
+    return this.setState({ username: { value: value, valid: isValid } });
   }
-
 
   getEmailValidationState() {
     if (!this.state) return;
@@ -85,12 +94,11 @@ class EmployeeForm extends Component {
 
   handleEmailChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ email: {value: value, valid: isValid }});
+    return this.setState({ email: { value: value, valid: isValid } });
   }
-
 
   getFirstNameValidationState() {
     if (!this.state) return;
@@ -100,12 +108,11 @@ class EmployeeForm extends Component {
 
   handleFirstNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ firstName: {value: value, valid: isValid }});
+    return this.setState({ firstName: { value: value, valid: isValid } });
   }
-
 
   getLastNameValidationState() {
     if (!this.state) return;
@@ -115,20 +122,20 @@ class EmployeeForm extends Component {
 
   handleLastNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ lastName: {value: value, valid: isValid }});
+    return this.setState({ lastName: { value: value, valid: isValid } });
   }
 
-  validateAll(){
+  validateAll() {
     return (
       //TODO: check all validation values here, instead of just returning true
       true
     );
   }
 
-  render () {
+  render() {
     return (
       <form>
         <FormGroup
@@ -140,7 +147,7 @@ class EmployeeForm extends Component {
             type="text"
             value={this.state.username.value}
             placeholder="Enter username"
-            onChange={(e) => this.handleUsernameChange(e.target.value)}
+            onChange={e => this.handleUsernameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
@@ -158,7 +165,7 @@ class EmployeeForm extends Component {
             type="text"
             value={this.state.lastName.value}
             placeholder="Enter lastName"
-            onChange={(e) => this.handleLastNameChange(e.target.value)}
+            onChange={e => this.handleLastNameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
@@ -171,13 +178,17 @@ class EmployeeForm extends Component {
           <div>
             <ButtonGroup>
               <Button
-                onClick={() => {this.handleAdminChange(true)}}
+                onClick={() => {
+                  this.handleAdminChange(true);
+                }}
                 bsStyle={this.state.admin.value === true ? 'success' : ''}
               >
                 Yes
               </Button>
               <Button
-                onClick={() => {this.handleAdminChange(false)}}
+                onClick={() => {
+                  this.handleAdminChange(false);
+                }}
                 bsStyle={this.state.admin.value === false ? 'danger' : ''}
               >
                 No

--- a/lab-05-form-validation/src/components/employees/EmployeeForm.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeForm.js
@@ -1,13 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {
-  Button,
-  FormGroup,
-  ControlLabel,
-  FormControl,
-  ButtonGroup
-} from 'react-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl, ButtonGroup } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import { withRouter } from 'react-router';
 
@@ -25,22 +19,16 @@ class EmployeeForm extends Component {
     };
 
     this.handleUsernameChange = this.handleUsernameChange.bind(this);
-    this.getUsernameValidationState = this.getUsernameValidationState.bind(
-      this
-    );
+    this.getUsernameValidationState = this.getUsernameValidationState.bind(this);
 
     this.handleEmailChange = this.handleEmailChange.bind(this);
     this.getEmailValidationState = this.getEmailValidationState.bind(this);
 
     this.handleFirstNameChange = this.handleFirstNameChange.bind(this);
-    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(
-      this
-    );
+    this.getFirstNameValidationState = this.getFirstNameValidationState.bind(this);
 
     this.handleLastNameChange = this.handleLastNameChange.bind(this);
-    this.getLastNameValidationState = this.getLastNameValidationState.bind(
-      this
-    );
+    this.getLastNameValidationState = this.getLastNameValidationState.bind(this);
 
     this.handleAdminChange = this.handleAdminChange.bind(this);
     this.getAdminValidationState = this.getAdminValidationState.bind(this);
@@ -138,10 +126,7 @@ class EmployeeForm extends Component {
   render() {
     return (
       <form>
-        <FormGroup
-          controlId="username"
-          validationState={this.getUsernameValidationState()}
-        >
+        <FormGroup controlId="username" validationState={this.getUsernameValidationState()}>
           <ControlLabel>Username</ControlLabel>
           <FormControl
             type="text"
@@ -156,10 +141,7 @@ class EmployeeForm extends Component {
 
         {/*TODO: Implement firstName form control here*/}
 
-        <FormGroup
-          controlId="lastName"
-          validationState={this.getLastNameValidationState()}
-        >
+        <FormGroup controlId="lastName" validationState={this.getLastNameValidationState()}>
           <ControlLabel>Last Name</ControlLabel>
           <FormControl
             type="text"
@@ -170,10 +152,7 @@ class EmployeeForm extends Component {
           <FormControl.Feedback />
         </FormGroup>
 
-        <FormGroup
-          controlId="admin"
-          validationState={this.getAdminValidationState()}
-        >
+        <FormGroup controlId="admin" validationState={this.getAdminValidationState()}>
           <ControlLabel>Admin</ControlLabel>
           <div>
             <ButtonGroup>

--- a/lab-05-form-validation/src/components/employees/EmployeeRow.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeRow.js
@@ -8,14 +8,10 @@ class EmployeeRow extends Component {
   handleClick(employee) {
     if (employee.deleted) {
       employee.deleted = false;
-      this.props.actions
-        .restoreEmployee(employee)
-        .then(this.props.actions.listEmployees);
+      this.props.actions.restoreEmployee(employee).then(this.props.actions.listEmployees);
     } else {
       employee.deleted = true;
-      this.props.actions
-        .removeEmployee(employee)
-        .then(this.props.actions.listEmployees);
+      this.props.actions.removeEmployee(employee).then(this.props.actions.listEmployees);
     }
   }
 

--- a/lab-05-form-validation/src/components/employees/EmployeeRow.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeRow.js
@@ -1,19 +1,21 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class EmployeeRow extends Component {
-
   handleClick(employee) {
-    if(employee.deleted){
+    if (employee.deleted) {
       employee.deleted = false;
-      this.props.actions.restoreEmployee(employee).then(this.props.actions.listEmployees);
-    }
-    else{
+      this.props.actions
+        .restoreEmployee(employee)
+        .then(this.props.actions.listEmployees);
+    } else {
       employee.deleted = true;
-      this.props.actions.removeEmployee(employee).then(this.props.actions.listEmployees);
+      this.props.actions
+        .removeEmployee(employee)
+        .then(this.props.actions.listEmployees);
     }
   }
 
@@ -22,19 +24,22 @@ class EmployeeRow extends Component {
   render() {
     const employee = this.props.employee;
 
-    let rowClass = "";
-    if(employee.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (employee.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(employee); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(employee);
+          e.stopPropagation();
+        }}
         bsStyle={employee.deleted ? 'success' : 'danger'}
       >
         {employee.deleted ? 'Restore' : 'Delete'}
-      </Button>);
-
+      </Button>
+    );
 
     //TODO: Add onClick function to call showDetail in tr tag below
     return (
@@ -48,7 +53,6 @@ class EmployeeRow extends Component {
       </tr>
     );
   }
-
 }
 
 EmployeeRow.propTypes = {

--- a/lab-05-form-validation/src/components/employees/EmployeeRow.test.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeRow.test.js
@@ -1,28 +1,26 @@
 import React from 'react';
 import EmployeeRow from './EmployeeRow';
 import { mount } from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Employee Row Component: ', () =>  {
+describe('Employee Row Component: ', () => {
+  it('should instantiate the Employee Row Component', () => {
+    const employee = {
+      username: 'fflintstone',
+      email: 'fred.flintstone@slatequarry.com',
+      firstName: 'Fred',
+      lastName: 'Flintstone',
+      admin: true
+    };
 
+    const component = mount(
+      <MemoryRouter>
+        <EmployeeRow employee={employee} />
+      </MemoryRouter>
+    );
 
-    it('should instantiate the Employee Row Component', () =>  {
-
-        const employee = {username:'fflintstone',
-                          'email':'fred.flintstone@slatequarry.com',
-                          'firstName':'Fred',
-                          'lastName':'Flintstone',
-                          'admin':true
-                         }
-
-        const component = mount(
-          <MemoryRouter><EmployeeRow employee={employee}/></MemoryRouter>
-        );
-
-        expect(component).toContainReact(<td>Flintstone</td>);
-        expect(component).toContainReact(<td>fflintstone</td>);
-        expect(component).toContainReact(<td>Yes</td>);
-
-    });
-
+    expect(component).toContainReact(<td>Flintstone</td>);
+    expect(component).toContainReact(<td>fflintstone</td>);
+    expect(component).toContainReact(<td>Yes</td>);
+  });
 });

--- a/lab-05-form-validation/src/components/employees/EmployeeTable.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeTable.js
@@ -9,9 +9,7 @@ class EmployeeTable extends Component {
     const actions = this.props.actions;
 
     let employeeRows = this.props.employees.map(employee => {
-      return (
-        <EmployeeRow employee={employee} key={employee._id} actions={actions} />
-      );
+      return <EmployeeRow employee={employee} key={employee._id} actions={actions} />;
     });
 
     return (

--- a/lab-05-form-validation/src/components/employees/EmployeeTable.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeTable.js
@@ -2,11 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import EmployeeRow from './EmployeeRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class EmployeeTable extends Component {
   render() {
-
     const actions = this.props.actions;
 
     let employeeRows = this.props.employees.map(employee => {
@@ -18,18 +17,16 @@ class EmployeeTable extends Component {
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Username</th>
-          <th>Email</th>
-          <th>First Name</th>
-          <th>Last Name</th>
-          <th>Admin</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Username</th>
+            <th>Email</th>
+            <th>First Name</th>
+            <th>Last Name</th>
+            <th>Admin</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-          {employeeRows}
-        </tbody>
+        <tbody>{employeeRows}</tbody>
       </Table>
     );
   }

--- a/lab-05-form-validation/src/components/employees/EmployeeTable.test.js
+++ b/lab-05-form-validation/src/components/employees/EmployeeTable.test.js
@@ -1,33 +1,30 @@
 import React from 'react';
 import EmployeeTable from './EmployeeTable';
 import { mount } from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Employee Table Component: ', () =>  {
+describe('Employee Table Component: ', () => {
+  it('should instantiate the Employee Table', () => {
+    const employees = [
+      {
+        username: 'fflintstone',
+        email: 'fred.flintstone@slatequarry.com',
+        firstName: 'Fred',
+        lastName: 'Flintstone',
+        admin: true,
+        _id: 1
+      }
+    ];
 
+    const component = mount(
+      <MemoryRouter>
+        <EmployeeTable employees={employees} />
+      </MemoryRouter>
+    );
 
-    it('should instantiate the Employee Table', () =>  {
+    expect(component).toContainReact(<th>Last Name</th>);
+    expect(component).toIncludeText('Flintstone');
 
-
-        const employees = [{username:'fflintstone',
-                          'email':'fred.flintstone@slatequarry.com',
-                          'firstName':'Fred',
-                          'lastName':'Flintstone',
-                          'admin':true,
-                          '_id':1
-                         }]
-
-
-
-        const component = mount(
-                <MemoryRouter><EmployeeTable employees={employees}/></MemoryRouter>
-        );
-
-        expect(component).toContainReact(<th>Last Name</th>);
-        expect(component).toIncludeText('Flintstone');
-
-        expect(component.find('tbody tr')).toHaveLength(1);
-
+    expect(component.find('tbody tr')).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/employees/Employees.js
+++ b/lab-05-form-validation/src/components/employees/Employees.js
@@ -22,10 +22,7 @@ class Employees extends Component {
         </Row>
         <Row>{/* TODO - Add a button to open the create employee route */}</Row>
         <Row>
-          <EmployeeTable
-            employees={this.props.employees}
-            actions={this.props.actions}
-          />
+          <EmployeeTable employees={this.props.employees} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/lab-05-form-validation/src/components/employees/Employees.js
+++ b/lab-05-form-validation/src/components/employees/Employees.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import EmployeeTable from './EmployeeTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 
 class Employees extends Component {
-
   constructor(props) {
     super(props);
 
@@ -21,32 +20,28 @@ class Employees extends Component {
         <Row>
           <PageHeader>Employees</PageHeader>
         </Row>
+        <Row>{/* TODO - Add a button to open the create employee route */}</Row>
         <Row>
-
-          {/* TODO - Add a button to open the create employee route */}
-
-        </Row>
-        <Row>
-          <EmployeeTable employees={this.props.employees} actions={this.props.actions}/>
+          <EmployeeTable
+            employees={this.props.employees}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     employees: state.employees.employees
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(EmployeeActions, dispatch)
   };
-}
+};
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Employees);
+export default connect(mapStateToProps, mapDispatchToProps)(Employees);

--- a/lab-05-form-validation/src/components/employees/Employees.test.js
+++ b/lab-05-form-validation/src/components/employees/Employees.test.js
@@ -2,19 +2,18 @@ import React from 'react';
 import Employees from './Employees';
 import { shallow, mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
 const mockStore = configureStore();
 
-describe('Employees Component: ', () =>  {
-
-  it('should instantiate the Employee Component', () =>  {
+describe('Employees Component: ', () => {
+  it('should instantiate the Employee Component', () => {
     const component = shallow(
-      <MemoryRouter><Employees store={mockStore}/></MemoryRouter>
+      <MemoryRouter>
+        <Employees store={mockStore} />
+      </MemoryRouter>
     );
 
-      expect(component).toHaveLength(1);
-
+    expect(component).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/employees/EmployeesCreate.js
+++ b/lab-05-form-validation/src/components/employees/EmployeesCreate.js
@@ -2,20 +2,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import EmployeeForm from './EmployeeForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 import { withRouter } from 'react-router';
 
 class EmployeesCreate extends Component {
-
   // TODO - implement me
 
   render() {
-    return (
-      <div/>
-    );
+    return <div />;
   }
 }
 
@@ -24,27 +21,22 @@ EmployeesCreate.defaultProps = {
 };
 
 EmployeesCreate.propTypes = {
-
   //TODO: Require the employee proptype
 
   history: PropTypes.object
 };
 
+const mapStateToProps = state => {
+  return {};
+};
 
-const mapStateToProps = (state) => {
-  return {
-  }
-}
-
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     //TODO: bind the redux action creators to the component props here
     //actions: bindActionCreators(EmployeeActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(EmployeesCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(EmployeesCreate)
+);

--- a/lab-05-form-validation/src/components/employees/EmployeesCreate.js
+++ b/lab-05-form-validation/src/components/employees/EmployeesCreate.js
@@ -37,6 +37,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(EmployeesCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EmployeesCreate));

--- a/lab-05-form-validation/src/components/employees/EmployeesDetail.js
+++ b/lab-05-form-validation/src/components/employees/EmployeesDetail.js
@@ -38,6 +38,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(EmployeesDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(EmployeesDetail));

--- a/lab-05-form-validation/src/components/employees/EmployeesDetail.js
+++ b/lab-05-form-validation/src/components/employees/EmployeesDetail.js
@@ -2,20 +2,17 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import EmployeeForm from './EmployeeForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 import { withRouter } from 'react-router';
 
 class EmployeesDetail extends Component {
-
   // TODO - implement me
 
   render() {
-    return (
-      <div/>
-    );
+    return <div />;
   }
 }
 
@@ -24,27 +21,23 @@ EmployeesDetail.defaultProps = {
 };
 
 EmployeesDetail.propTypes = {
-
   //TODO: require the employee object here
 
   history: PropTypes.object
 };
 
-
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     //TODO: map the redux store state to the component props here
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     //TODO: bind the action creators here
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(EmployeesDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(EmployeesDetail)
+);

--- a/lab-05-form-validation/src/components/employees/EmployeesDetail.test.js
+++ b/lab-05-form-validation/src/components/employees/EmployeesDetail.test.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import EmployeesDetail from './EmployeesDetail';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-
-describe('Employees Detail Component: ', () =>  {
+describe('Employees Detail Component: ', () => {
   let mockStore;
 
   beforeEach(() => {
@@ -13,7 +12,5 @@ describe('Employees Detail Component: ', () =>  {
   });
 
   //TODO: Implement me
-  it('should instantiate the Employees Detail Component', () =>  {
-  });
-
+  it('should instantiate the Employees Detail Component', () => {});
 });

--- a/lab-05-form-validation/src/components/nav/Navigation.js
+++ b/lab-05-form-validation/src/components/nav/Navigation.js
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
-import {Navbar, Nav, NavItem} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Navbar, Nav, NavItem } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class NavBar extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      user: {_id: 'all'}
+      user: { _id: 'all' }
     };
   }
 
@@ -14,9 +14,7 @@ class NavBar extends Component {
     return (
       <Navbar>
         <Navbar.Header>
-          <Navbar.Brand>
-            Timesheetz
-          </Navbar.Brand>
+          <Navbar.Brand>Timesheetz</Navbar.Brand>
         </Navbar.Header>
         <Nav>
           <LinkContainer to="/projects">

--- a/lab-05-form-validation/src/components/nav/Navigation.test.js
+++ b/lab-05-form-validation/src/components/nav/Navigation.test.js
@@ -3,18 +3,20 @@ import { mount } from 'enzyme';
 
 import Navigation from './Navigation';
 
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
-describe('Navigation Component: ', () =>  {
-
+describe('Navigation Component: ', () => {
   let nav;
 
-  beforeEach(() =>{
-    nav = mount(<BrowserRouter><Navigation /></BrowserRouter>);
+  beforeEach(() => {
+    nav = mount(
+      <BrowserRouter>
+        <Navigation />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Navigation Component', () =>  {
+  it('should instantiate the Navigation Component', () => {
     expect(nav).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/projects/ProjectForm.js
+++ b/lab-05-form-validation/src/components/projects/ProjectForm.js
@@ -18,9 +18,7 @@ class ProjectForm extends Component {
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
-      this
-    );
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -79,10 +77,7 @@ class ProjectForm extends Component {
   render() {
     return (
       <form>
-        <FormGroup
-          controlId="name"
-          validationState={this.getNameValidationState()}
-        >
+        <FormGroup controlId="name" validationState={this.getNameValidationState()}>
           <ControlLabel>Name</ControlLabel>
           <FormControl
             type="text"
@@ -92,10 +87,7 @@ class ProjectForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="description"
-          validationState={this.getDescriptionValidationState()}
-        >
+        <FormGroup controlId="description" validationState={this.getDescriptionValidationState()}>
           <ControlLabel>Description</ControlLabel>
           <FormControl
             type="text"
@@ -105,11 +97,7 @@ class ProjectForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <Button
-          bsStyle="success"
-          onClick={this.handleSave}
-          disabled={!this.validateAll()}
-        >
+        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}>
           {' '}
           Save{' '}
         </Button>&nbsp;

--- a/lab-05-form-validation/src/components/projects/ProjectForm.js
+++ b/lab-05-form-validation/src/components/projects/ProjectForm.js
@@ -1,24 +1,26 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { withRouter } from 'react-router';
 
 class ProjectForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     this.state = {
-      name: {value: null, valid: null},
-      description: {value: null, valid: null}
+      name: { value: null, valid: null },
+      description: { value: null, valid: null }
     };
 
     this.handleNameChange = this.handleNameChange.bind(this);
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
+      this
+    );
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -27,13 +29,13 @@ class ProjectForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     this.state = {
-      name: {value: nextProps.project.name, valid: null},
-      description: {value: nextProps.project.description, valid: null}
+      name: { value: nextProps.project.name, valid: null },
+      description: { value: nextProps.project.description, valid: null }
     };
   }
 
-  handleSave(){
-    if(this.validateAll()) {
+  handleSave() {
+    if (this.validateAll()) {
       this.props.handleSave({
         name: this.state.name.value,
         description: this.state.description.value,
@@ -50,10 +52,10 @@ class ProjectForm extends Component {
 
   handleDescriptionChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ description: {value: value, valid: isValid }});
+    return this.setState({ description: { value: value, valid: isValid } });
   }
 
   getNameValidationState() {
@@ -64,20 +66,17 @@ class ProjectForm extends Component {
 
   handleNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ name: {value: value, valid: isValid }});
+    return this.setState({ name: { value: value, valid: isValid } });
   }
 
-  validateAll(){
-    return (
-      this.state.name.value
-      && this.state.description.value
-    );
+  validateAll() {
+    return this.state.name.value && this.state.description.value;
   }
 
-  render () {
+  render() {
     return (
       <form>
         <FormGroup
@@ -89,11 +88,10 @@ class ProjectForm extends Component {
             type="text"
             value={this.state.name.value}
             placeholder="Enter name"
-            onChange={(e) => this.handleNameChange(e.target.value)}
+            onChange={e => this.handleNameChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="description"
           validationState={this.getDescriptionValidationState()}
@@ -103,12 +101,18 @@ class ProjectForm extends Component {
             type="text"
             value={this.state.description.value}
             placeholder="Enter description"
-            onChange={(e) => this.handleDescriptionChange(e.target.value)}
+            onChange={e => this.handleDescriptionChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
-        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}> Save </Button>&nbsp;
+        <Button
+          bsStyle="success"
+          onClick={this.handleSave}
+          disabled={!this.validateAll()}
+        >
+          {' '}
+          Save{' '}
+        </Button>&nbsp;
         <LinkContainer to="/projects">
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>

--- a/lab-05-form-validation/src/components/projects/ProjectRow.js
+++ b/lab-05-form-validation/src/components/projects/ProjectRow.js
@@ -7,14 +7,10 @@ class ProjectRow extends Component {
   handleClick(project) {
     if (project.deleted) {
       project.deleted = false;
-      this.props.actions
-        .restoreProject(project)
-        .then(this.props.actions.listProjects);
+      this.props.actions.restoreProject(project).then(this.props.actions.listProjects);
     } else {
       project.deleted = true;
-      this.props.actions
-        .removeProject(project)
-        .then(this.props.actions.listProjects);
+      this.props.actions.removeProject(project).then(this.props.actions.listProjects);
     }
   }
 

--- a/lab-05-form-validation/src/components/projects/ProjectRow.js
+++ b/lab-05-form-validation/src/components/projects/ProjectRow.js
@@ -1,23 +1,25 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class ProjectRow extends Component {
-
   handleClick(project) {
-    if(project.deleted){
+    if (project.deleted) {
       project.deleted = false;
-      this.props.actions.restoreProject(project).then(this.props.actions.listProjects);
-    }
-    else{
+      this.props.actions
+        .restoreProject(project)
+        .then(this.props.actions.listProjects);
+    } else {
       project.deleted = true;
-      this.props.actions.removeProject(project).then(this.props.actions.listProjects);
+      this.props.actions
+        .removeProject(project)
+        .then(this.props.actions.listProjects);
     }
   }
 
   showDetail(project) {
-    if(project.deleted) {
+    if (project.deleted) {
       console.log('You cannot edit a deleted project.');
       return;
     }
@@ -26,21 +28,30 @@ class ProjectRow extends Component {
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.project.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.project.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(this.props.project); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(this.props.project);
+          e.stopPropagation();
+        }}
         bsStyle={this.props.project.deleted ? 'success' : 'danger'}
       >
         {this.props.project.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
-      <tr className={rowClass} onClick={() => {this.showDetail(this.props.project)}}>
+      <tr
+        className={rowClass}
+        onClick={() => {
+          this.showDetail(this.props.project);
+        }}
+      >
         <td>{this.props.project.name}</td>
         <td>{this.props.project.description}</td>
         <td>{button}</td>

--- a/lab-05-form-validation/src/components/projects/ProjectRow.test.js
+++ b/lab-05-form-validation/src/components/projects/ProjectRow.test.js
@@ -2,19 +2,21 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ProjectRow from './ProjectRow';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Project Row Component: ', () =>  {
-
+describe('Project Row Component: ', () => {
   let projectRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const project = {};
-    projectRow = mount(<MemoryRouter><ProjectRow project={project} /></MemoryRouter>);
+    projectRow = mount(
+      <MemoryRouter>
+        <ProjectRow project={project} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Project Row Component', () =>  {
+  it('should instantiate the Project Row Component', () => {
     expect(projectRow).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/projects/ProjectTable.js
+++ b/lab-05-form-validation/src/components/projects/ProjectTable.js
@@ -2,31 +2,28 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectRow from './ProjectRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class ProjectTable extends Component {
   render() {
-
     const actions = this.props.actions;
 
     const projectRows = this.props.projects.map(project => {
       return (
-        <ProjectRow project={project} key={project._id} actions={actions}/>
+        <ProjectRow project={project} key={project._id} actions={actions} />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {projectRows}
-        </tbody>
+        <tbody>{projectRows}</tbody>
       </Table>
     );
   }

--- a/lab-05-form-validation/src/components/projects/ProjectTable.js
+++ b/lab-05-form-validation/src/components/projects/ProjectTable.js
@@ -9,9 +9,7 @@ class ProjectTable extends Component {
     const actions = this.props.actions;
 
     const projectRows = this.props.projects.map(project => {
-      return (
-        <ProjectRow project={project} key={project._id} actions={actions} />
-      );
+      return <ProjectRow project={project} key={project._id} actions={actions} />;
     });
 
     return (

--- a/lab-05-form-validation/src/components/projects/ProjectTable.test.js
+++ b/lab-05-form-validation/src/components/projects/ProjectTable.test.js
@@ -2,19 +2,21 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ProjectTable from './ProjectTable';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Project Table Component: ', () =>  {
-
+describe('Project Table Component: ', () => {
   let projectTable;
 
-  beforeEach(() =>{
-    const projects = [{_id: 1}, {_id: 2}];
-    projectTable = mount(<MemoryRouter><ProjectTable projects={projects} /></MemoryRouter>);
+  beforeEach(() => {
+    const projects = [{ _id: 1 }, { _id: 2 }];
+    projectTable = mount(
+      <MemoryRouter>
+        <ProjectTable projects={projects} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Project Table Component', () =>  {
+  it('should instantiate the Project Table Component', () => {
     expect(projectTable).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/projects/Projects.js
+++ b/lab-05-form-validation/src/components/projects/Projects.js
@@ -31,10 +31,7 @@ class Projects extends Component {
           </div>
         </Row>
         <Row>
-          <ProjectTable
-            projects={this.props.projects}
-            actions={this.props.actions}
-          />
+          <ProjectTable projects={this.props.projects} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/lab-05-form-validation/src/components/projects/Projects.js
+++ b/lab-05-form-validation/src/components/projects/Projects.js
@@ -1,14 +1,13 @@
 import React, { Component } from 'react';
 
 import ProjectTable from './ProjectTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
 class Projects extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listProjects();
@@ -16,9 +15,7 @@ class Projects extends Component {
     this.createProject = this.createProject.bind(this);
   }
 
-  createProject(){
-
-  }
+  createProject() {}
 
   render() {
     return (
@@ -34,26 +31,26 @@ class Projects extends Component {
           </div>
         </Row>
         <Row>
-          <ProjectTable projects={this.props.projects} actions={this.props.actions}/>
+          <ProjectTable
+            projects={this.props.projects}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     projects: state.projects.projects
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Projects);
+export default connect(mapStateToProps, mapDispatchToProps)(Projects);

--- a/lab-05-form-validation/src/components/projects/Projects.test.js
+++ b/lab-05-form-validation/src/components/projects/Projects.test.js
@@ -3,19 +3,21 @@ import { mount } from 'enzyme';
 
 import Projects from './Projects';
 import configureStore from '../../store/configure-store';
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
-describe('Projects Component: ', () =>  {
-
+describe('Projects Component: ', () => {
   let projects;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    projects = mount(<BrowserRouter><Projects store={mockStore}/></BrowserRouter>);
+  beforeEach(() => {
+    projects = mount(
+      <BrowserRouter>
+        <Projects store={mockStore} />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Project Component', () =>  {
+  it('should instantiate the Project Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/projects/ProjectsCreate.js
+++ b/lab-05-form-validation/src/components/projects/ProjectsCreate.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectForm from './ProjectForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 import { withRouter } from 'react-router';
 
 class ProjectsCreate extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listProjects();
@@ -17,7 +16,7 @@ class ProjectsCreate extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(project){
+  handleSave(project) {
     this.props.actions.createProject(project).then(() => {
       this.props.history.push('/projects');
     });
@@ -30,7 +29,11 @@ class ProjectsCreate extends Component {
           <PageHeader>Projects Create</PageHeader>
         </Row>
         <Row>
-          <ProjectForm project={this.props.project} actions={this.props.actions} handleSave={this.handleSave}/>
+          <ProjectForm
+            project={this.props.project}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
@@ -46,19 +49,16 @@ ProjectsCreate.defaultProps = {
   project: {}
 };
 
-const mapStateToProps = (state) => {
-  return {
-  }
-}
+const mapStateToProps = state => {
+  return {};
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ProjectsCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(ProjectsCreate)
+);

--- a/lab-05-form-validation/src/components/projects/ProjectsCreate.js
+++ b/lab-05-form-validation/src/components/projects/ProjectsCreate.js
@@ -59,6 +59,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(ProjectsCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ProjectsCreate));

--- a/lab-05-form-validation/src/components/projects/ProjectsCreate.test.js
+++ b/lab-05-form-validation/src/components/projects/ProjectsCreate.test.js
@@ -1,28 +1,29 @@
 import React from 'react';
 import ProjectsCreate from './ProjectsCreate';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
-describe('Projects Create Component: ', () =>  {
-
+describe('Projects Create Component: ', () => {
   let projects;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
+  beforeEach(() => {
     //Mock out the server call in the constructor
-    ProjectActions.listProjects = ()=>{
-      return (dispatch) => {
-      };
+    ProjectActions.listProjects = () => {
+      return dispatch => {};
     };
 
-    projects = mount(<BrowserRouter><ProjectsCreate store={mockStore}/></BrowserRouter>);
+    projects = mount(
+      <BrowserRouter>
+        <ProjectsCreate store={mockStore} />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Projects Create Component', () =>  {
+  it('should instantiate the Projects Create Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/projects/ProjectsDetail.js
+++ b/lab-05-form-validation/src/components/projects/ProjectsDetail.js
@@ -63,6 +63,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(ProjectsDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(ProjectsDetail));

--- a/lab-05-form-validation/src/components/projects/ProjectsDetail.js
+++ b/lab-05-form-validation/src/components/projects/ProjectsDetail.js
@@ -2,14 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import ProjectForm from './ProjectForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 import { withRouter } from 'react-router';
 
 class ProjectsDetail extends Component {
-
   constructor(props) {
     super(props);
 
@@ -19,7 +18,7 @@ class ProjectsDetail extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(project){
+  handleSave(project) {
     this.props.actions.updateProject(project).then(() => {
       this.props.history.push('/projects');
     });
@@ -32,7 +31,11 @@ class ProjectsDetail extends Component {
           <PageHeader>Projects Detail</PageHeader>
         </Row>
         <Row>
-          <ProjectForm project={this.props.project} actions={this.props.actions} handleSave={this.handleSave}/>
+          <ProjectForm
+            project={this.props.project}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
@@ -48,20 +51,18 @@ ProjectsDetail.defaultProps = {
   project: {}
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     project: state.projects.project
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ProjectsDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(ProjectsDetail)
+);

--- a/lab-05-form-validation/src/components/projects/ProjectsDetail.test.js
+++ b/lab-05-form-validation/src/components/projects/ProjectsDetail.test.js
@@ -1,29 +1,30 @@
 import React from 'react';
 import ProjectsDetail from './ProjectsDetail';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {BrowserRouter} from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
 
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
-describe('Projects Detail Component: ', () =>  {
-
+describe('Projects Detail Component: ', () => {
   let projects;
   const mockStore = configureStore();
-  const mockMatch = {params: {_id: 1}};
+  const mockMatch = { params: { _id: 1 } };
 
-  beforeEach(() =>{
+  beforeEach(() => {
     //Mock out the server call in the constructor
-    ProjectActions.getProject = (id)=>{
-      return (dispatch) => {
-      };
+    ProjectActions.getProject = id => {
+      return dispatch => {};
     };
 
-    projects = mount(<BrowserRouter><ProjectsDetail store={mockStore} match={mockMatch}/></BrowserRouter>);
+    projects = mount(
+      <BrowserRouter>
+        <ProjectsDetail store={mockStore} match={mockMatch} />
+      </BrowserRouter>
+    );
   });
 
-  it('should instantiate the Projects Detail Component', () =>  {
+  it('should instantiate the Projects Detail Component', () => {
     expect(projects).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/timesheets/TimesheetForm.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetForm.js
@@ -1,28 +1,32 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class TimesheetForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     this.state = {
-      name: {value: null, valid: null},
-      description: {value: null, valid: null},
-      beginDate: {value: null, valid: null},
-      endDate: {value: null, valid: null}
+      name: { value: null, valid: null },
+      description: { value: null, valid: null },
+      beginDate: { value: null, valid: null },
+      endDate: { value: null, valid: null }
     };
 
     this.handleNameChange = this.handleNameChange.bind(this);
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
+      this
+    );
 
     this.handleBeginDateChange = this.handleBeginDateChange.bind(this);
-    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(this);
+    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(
+      this
+    );
 
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
     this.getEndDateValidationState = this.getEndDateValidationState.bind(this);
@@ -35,12 +39,10 @@ class TimesheetForm extends Component {
   }
 
   // TODO - implement me
-  componentWillReceiveProps(nextProps) {
-  }
+  componentWillReceiveProps(nextProps) {}
 
   // TODO - implement me
-  handleSave(){
-  }
+  handleSave() {}
 
   getDescriptionValidationState() {
     if (!this.state) return;
@@ -50,10 +52,10 @@ class TimesheetForm extends Component {
 
   handleDescriptionChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ description: {value: value, valid: isValid }});
+    return this.setState({ description: { value: value, valid: isValid } });
   }
 
   getNameValidationState() {
@@ -64,10 +66,10 @@ class TimesheetForm extends Component {
 
   handleNameChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ name: {value: value, valid: isValid }});
+    return this.setState({ name: { value: value, valid: isValid } });
   }
 
   getBeginDateValidationState() {
@@ -78,11 +80,11 @@ class TimesheetForm extends Component {
 
   handleBeginDateChange(value) {
     let isValid = false,
-        dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
-    if(dateRegExp.test(value)){
-        isValid = true;
+      dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
+    if (dateRegExp.test(value)) {
+      isValid = true;
     }
-    return this.setState({ beginDate: {value: value, valid: isValid }});
+    return this.setState({ beginDate: { value: value, valid: isValid } });
   }
 
   getEndDateValidationState() {
@@ -93,35 +95,33 @@ class TimesheetForm extends Component {
 
   handleEndDateChange(value) {
     let isValid = false,
-        dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
-    if(dateRegExp.test(value)){
-        isValid = true;
+      dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
+    if (dateRegExp.test(value)) {
+      isValid = true;
     }
-    return this.setState({ endDate: {value: value, valid: isValid }});
+    return this.setState({ endDate: { value: value, valid: isValid } });
   }
 
-  validateAll(){
+  validateAll() {
     return (
-      this.state.name.value
-      && this.state.description.value
-      && this.state.beginDate.value
-      && this.state.endDate.value
+      this.state.name.value &&
+      this.state.description.value &&
+      this.state.beginDate.value &&
+      this.state.endDate.value
     );
   }
 
   handleEmployeeChange(value) {
     let isValid = false;
-    if(value){
-        isValid = true;
+    if (value) {
+      isValid = true;
     }
-    return this.setState({ user_id: {value: value, valid: isValid }});
+    return this.setState({ user_id: { value: value, valid: isValid } });
   }
 
   // TODO - implement me
-  render () {
-    return (
-      <div/>
-    );
+  render() {
+    return <div />;
   }
 }
 

--- a/lab-05-form-validation/src/components/timesheets/TimesheetForm.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetForm.js
@@ -19,14 +19,10 @@ class TimesheetForm extends Component {
     this.getNameValidationState = this.getNameValidationState.bind(this);
 
     this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
-    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(
-      this
-    );
+    this.getDescriptionValidationState = this.getDescriptionValidationState.bind(this);
 
     this.handleBeginDateChange = this.handleBeginDateChange.bind(this);
-    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(
-      this
-    );
+    this.getBeginDateValidationState = this.getBeginDateValidationState.bind(this);
 
     this.handleEndDateChange = this.handleEndDateChange.bind(this);
     this.getEndDateValidationState = this.getEndDateValidationState.bind(this);

--- a/lab-05-form-validation/src/components/timesheets/TimesheetRow.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetRow.js
@@ -1,47 +1,60 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class TimesheetRow extends Component {
-
   handleClick(timesheet) {
-    if(timesheet.deleted){
+    if (timesheet.deleted) {
       timesheet.deleted = false;
-      this.props.actions.restoreTimesheet(timesheet).then(this.props.actions.listTimesheets);
-    }
-    else{
+      this.props.actions
+        .restoreTimesheet(timesheet)
+        .then(this.props.actions.listTimesheets);
+    } else {
       timesheet.deleted = true;
-      this.props.actions.removeTimesheet(timesheet).then(this.props.actions.listTimesheets);
+      this.props.actions
+        .removeTimesheet(timesheet)
+        .then(this.props.actions.listTimesheets);
     }
   }
 
   showDetail(timesheet) {
-    if(timesheet.deleted) {
+    if (timesheet.deleted) {
       console.log('You cannot edit a deleted timesheet.');
       return;
     }
 
-    this.props.history.push('/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id);
+    this.props.history.push(
+      '/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id
+    );
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.timesheet.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.timesheet.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(this.props.timesheet); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(this.props.timesheet);
+          e.stopPropagation();
+        }}
         bsStyle={this.props.timesheet.deleted ? 'success' : 'danger'}
       >
         {this.props.timesheet.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
-      <tr className={rowClass} onClick={() => {this.showDetail(this.props.timesheet)}}>
+      <tr
+        className={rowClass}
+        onClick={() => {
+          this.showDetail(this.props.timesheet);
+        }}
+      >
         <td>{this.props.timesheet.beginDate}</td>
         <td>{this.props.timesheet.endDate}</td>
         <td>{this.props.timesheet.name}</td>

--- a/lab-05-form-validation/src/components/timesheets/TimesheetRow.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetRow.js
@@ -8,14 +8,10 @@ class TimesheetRow extends Component {
   handleClick(timesheet) {
     if (timesheet.deleted) {
       timesheet.deleted = false;
-      this.props.actions
-        .restoreTimesheet(timesheet)
-        .then(this.props.actions.listTimesheets);
+      this.props.actions.restoreTimesheet(timesheet).then(this.props.actions.listTimesheets);
     } else {
       timesheet.deleted = true;
-      this.props.actions
-        .removeTimesheet(timesheet)
-        .then(this.props.actions.listTimesheets);
+      this.props.actions.removeTimesheet(timesheet).then(this.props.actions.listTimesheets);
     }
   }
 

--- a/lab-05-form-validation/src/components/timesheets/TimesheetRow.test.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetRow.test.js
@@ -2,20 +2,22 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import TimesheetRow from './TimesheetRow';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timesheet Row Component: ', () =>  {
-
+describe('Timesheet Row Component: ', () => {
   let timesheetRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const timesheet = {};
     const routerStub = {};
-    timesheetRow = mount(<MemoryRouter><TimesheetRow timesheet={timesheet} actions={{}} route={routerStub} /></MemoryRouter>);
+    timesheetRow = mount(
+      <MemoryRouter>
+        <TimesheetRow timesheet={timesheet} actions={{}} route={routerStub} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheetRow).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/timesheets/TimesheetTable.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetTable.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimesheetRow from './TimesheetRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class TimesheetTable extends Component {
   render() {
@@ -10,24 +10,26 @@ class TimesheetTable extends Component {
 
     let timesheetRows = this.props.timesheets.map(timesheet => {
       return (
-        <TimesheetRow timesheet={timesheet} key={timesheet._id} actions={actions}/>
+        <TimesheetRow
+          timesheet={timesheet}
+          key={timesheet._id}
+          actions={actions}
+        />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Begin Date</th>
-          <th>End Date</th>
-          <th>Name</th>
-          <th>Description</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Begin Date</th>
+            <th>End Date</th>
+            <th>Name</th>
+            <th>Description</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {timesheetRows}
-        </tbody>
+        <tbody>{timesheetRows}</tbody>
       </Table>
     );
   }

--- a/lab-05-form-validation/src/components/timesheets/TimesheetTable.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetTable.js
@@ -9,13 +9,7 @@ class TimesheetTable extends Component {
     const actions = this.props.actions;
 
     let timesheetRows = this.props.timesheets.map(timesheet => {
-      return (
-        <TimesheetRow
-          timesheet={timesheet}
-          key={timesheet._id}
-          actions={actions}
-        />
-      );
+      return <TimesheetRow timesheet={timesheet} key={timesheet._id} actions={actions} />;
     });
 
     return (

--- a/lab-05-form-validation/src/components/timesheets/TimesheetTable.test.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetTable.test.js
@@ -2,19 +2,21 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import TimesheetTable from './TimesheetTable';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timesheet Table Component: ', () =>  {
-
+describe('Timesheet Table Component: ', () => {
   let timesheetTable;
 
-  beforeEach(() =>{
-    const timesheets = [{_id: 1}, {_id: 2}];
-    timesheetTable = mount(<MemoryRouter><TimesheetTable timesheets={timesheets} actions={{}} /></MemoryRouter>);
+  beforeEach(() => {
+    const timesheets = [{ _id: 1 }, { _id: 2 }];
+    timesheetTable = mount(
+      <MemoryRouter>
+        <TimesheetTable timesheets={timesheets} actions={{}} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timesheet Table Component', () =>  {
+  it('should instantiate the Timesheet Table Component', () => {
     expect(timesheetTable).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/timesheets/Timesheets.js
+++ b/lab-05-form-validation/src/components/timesheets/Timesheets.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import TimesheetTable from './TimesheetTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimesheetActions from '../../actions/TimesheetActionCreator';
-import {LinkContainer} from 'react-router-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class Timesheets extends Component {
-
   constructor(props) {
     super(props);
     props.actions.listTimesheets();
@@ -27,27 +26,26 @@ class Timesheets extends Component {
           </div>
         </Row>
         <Row>
-          <TimesheetTable timesheets={this.props.timesheets} actions={this.props.actions}/>
+          <TimesheetTable
+            timesheets={this.props.timesheets}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timesheets: state.timesheets.timesheets
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimesheetActions, dispatch)
   };
-}
+};
 
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Timesheets);
+export default connect(mapStateToProps, mapDispatchToProps)(Timesheets);

--- a/lab-05-form-validation/src/components/timesheets/Timesheets.js
+++ b/lab-05-form-validation/src/components/timesheets/Timesheets.js
@@ -26,10 +26,7 @@ class Timesheets extends Component {
           </div>
         </Row>
         <Row>
-          <TimesheetTable
-            timesheets={this.props.timesheets}
-            actions={this.props.actions}
-          />
+          <TimesheetTable timesheets={this.props.timesheets} actions={this.props.actions} />
         </Row>
       </Grid>
     );

--- a/lab-05-form-validation/src/components/timesheets/Timesheets.test.js
+++ b/lab-05-form-validation/src/components/timesheets/Timesheets.test.js
@@ -3,19 +3,21 @@ import { mount } from 'enzyme';
 
 import Timesheets from './Timesheets';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timesheets Component: ', () =>  {
-
+describe('Timesheets Component: ', () => {
   let timesheets;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    timesheets = mount(<MemoryRouter><Timesheets store={mockStore}/></MemoryRouter>);
+  beforeEach(() => {
+    timesheets = mount(
+      <MemoryRouter>
+        <Timesheets store={mockStore} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timesheet Component', () =>  {
+  it('should instantiate the Timesheet Component', () => {
     expect(timesheets).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/timesheets/TimesheetsCreate.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetsCreate.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimesheetForm from './TimesheetForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimesheetActions from '../../actions/TimesheetActionCreator';
@@ -10,13 +10,10 @@ import * as EmployeeActions from '../../actions/EmployeeActionCreator';
 import { withRouter } from 'react-router';
 
 class TimesheetsCreate extends Component {
-
   // TODO - implement me
 
   render() {
-    return (
-      <div/>
-    );
+    return <div />;
   }
 }
 
@@ -28,21 +25,19 @@ TimesheetsCreate.defaultProps = {
   employees: []
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
-      employees: state.employees.employees
-  }
-}
+    employees: state.employees.employees
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimesheetActions, dispatch),
     employeeActions: bindActionCreators(EmployeeActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimesheetsCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimesheetsCreate)
+);

--- a/lab-05-form-validation/src/components/timesheets/TimesheetsCreate.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetsCreate.js
@@ -38,6 +38,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimesheetsCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimesheetsCreate));

--- a/lab-05-form-validation/src/components/timesheets/TimesheetsDetail.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetsDetail.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimesheetActions from '../../actions/TimesheetActionCreator';
@@ -8,7 +8,6 @@ import Timeunits from '../timeunits/Timeunits';
 import TimesheetForm from './TimesheetForm';
 
 class TimesheetsDetail extends Component {
-
   constructor(props) {
     super(props);
 
@@ -21,32 +20,26 @@ class TimesheetsDetail extends Component {
   }
 
   // TODO - implement me
-  handleSave(timesheet) {
-
-  }
+  handleSave(timesheet) {}
 
   // TODO - implement me, too
   render() {
-    return (
-      <div/>
-    );
+    return <div />;
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timesheet: state.timesheets.timesheet
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimesheetActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimesheetsDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimesheetsDetail)
+);

--- a/lab-05-form-validation/src/components/timesheets/TimesheetsDetail.js
+++ b/lab-05-form-validation/src/components/timesheets/TimesheetsDetail.js
@@ -40,6 +40,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimesheetsDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimesheetsDetail));

--- a/lab-05-form-validation/src/components/timeunits/TimeunitForm.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitForm.js
@@ -1,27 +1,31 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button, FormGroup, ControlLabel, FormControl} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { Button, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 
 class TimeunitForm extends Component {
-  constructor(props){
+  constructor(props) {
     super(props);
 
     this.state = {
-      project: {value: null, valid: null},
-      dateWorked: {value: null, valid: null},
-      hoursWorked: {value: null, valid: null}
+      project: { value: null, valid: null },
+      dateWorked: { value: null, valid: null },
+      hoursWorked: { value: null, valid: null }
     };
 
     this.handleProjectChange = this.handleProjectChange.bind(this);
     this.getProjectValidationState = this.getProjectValidationState.bind(this);
 
     this.handleDateWorkedChange = this.handleDateWorkedChange.bind(this);
-    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(this);
+    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(
+      this
+    );
 
     this.handleHoursWorkedChange = this.handleHoursWorkedChange.bind(this);
-    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(this);
+    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(
+      this
+    );
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -30,14 +34,14 @@ class TimeunitForm extends Component {
 
   componentWillReceiveProps(nextProps) {
     this.state = {
-      project: {value: nextProps.timeunit.project, valid: null},
-      dateWorked: {value: nextProps.timeunit.dateWorked, valid: null},
-      hoursWorked: {value: nextProps.timeunit.hoursWorked, valid: null}
+      project: { value: nextProps.timeunit.project, valid: null },
+      dateWorked: { value: nextProps.timeunit.dateWorked, valid: null },
+      hoursWorked: { value: nextProps.timeunit.hoursWorked, valid: null }
     };
   }
 
-  handleSave(){
-    if(this.validateAll()) {
+  handleSave() {
+    if (this.validateAll()) {
       this.props.handleSave({
         project: this.state.project.value,
         dateWorked: this.state.dateWorked.value,
@@ -56,10 +60,10 @@ class TimeunitForm extends Component {
 
   handleProjectChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ project: {value: value, valid: isValid }});
+    return this.setState({ project: { value: value, valid: isValid } });
   }
 
   getDateWorkedValidationState() {
@@ -70,11 +74,11 @@ class TimeunitForm extends Component {
 
   handleDateWorkedChange(value) {
     let isValid = false,
-        dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
-    if(dateRegExp.test(value)){
+      dateRegExp = /^\d{4}-\d{1,2}-\d{1,2}$/;
+    if (dateRegExp.test(value)) {
       isValid = true;
     }
-    return this.setState({ dateWorked: {value: value, valid: isValid }});
+    return this.setState({ dateWorked: { value: value, valid: isValid } });
   }
 
   getHoursWorkedValidationState() {
@@ -85,21 +89,21 @@ class TimeunitForm extends Component {
 
   handleHoursWorkedChange(value) {
     let isValid = false;
-    if(value){
+    if (value) {
       isValid = true;
     }
-    return this.setState({ hoursWorked: {value: value, valid: isValid }});
+    return this.setState({ hoursWorked: { value: value, valid: isValid } });
   }
 
-  validateAll(){
+  validateAll() {
     return (
-      this.state.project.value
-      && this.state.dateWorked.value
-      && this.state.hoursWorked.value
+      this.state.project.value &&
+      this.state.dateWorked.value &&
+      this.state.hoursWorked.value
     );
   }
 
-  render () {
+  render() {
     return (
       <form>
         <FormGroup
@@ -111,19 +115,17 @@ class TimeunitForm extends Component {
             value={this.state.project.value}
             placeholder="Project1"
             componentClass="select"
-            onChange={(e) => this.handleProjectChange(e.target.value)}
+            onChange={e => this.handleProjectChange(e.target.value)}
           >
-            <option value="" disabled selected>Select a project</option>
-            {
-              this.props.projects
-              .map((project) => {
-                return <option value={project.name}>{project.name}</option>
-              })
-            }
+            <option value="" disabled selected>
+              Select a project
+            </option>
+            {this.props.projects.map(project => {
+              return <option value={project.name}>{project.name}</option>;
+            })}
           </FormControl>
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="dateWorked"
           validationState={this.getDateWorkedValidationState()}
@@ -133,11 +135,10 @@ class TimeunitForm extends Component {
             type="text"
             value={this.state.dateWorked.value}
             placeholder="YYYY-MM-DD"
-            onChange={(e) => this.handleDateWorkedChange(e.target.value)}
+            onChange={e => this.handleDateWorkedChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
         <FormGroup
           controlId="hoursWorked"
           validationState={this.getHoursWorkedValidationState()}
@@ -147,13 +148,26 @@ class TimeunitForm extends Component {
             type="text"
             value={this.state.hoursWorked.value}
             placeholder="Number of hours worked"
-            onChange={(e) => this.handleHoursWorkedChange(e.target.value)}
+            onChange={e => this.handleHoursWorkedChange(e.target.value)}
           />
           <FormControl.Feedback />
         </FormGroup>
-
-        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}> Save </Button>&nbsp;
-        <LinkContainer to={'/employees/' + this.props.userId + '/timesheets/detail/' + this.props.timesheetId}>
+        <Button
+          bsStyle="success"
+          onClick={this.handleSave}
+          disabled={!this.validateAll()}
+        >
+          {' '}
+          Save{' '}
+        </Button>&nbsp;
+        <LinkContainer
+          to={
+            '/employees/' +
+            this.props.userId +
+            '/timesheets/detail/' +
+            this.props.timesheetId
+          }
+        >
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>
       </form>

--- a/lab-05-form-validation/src/components/timeunits/TimeunitForm.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitForm.js
@@ -18,14 +18,10 @@ class TimeunitForm extends Component {
     this.getProjectValidationState = this.getProjectValidationState.bind(this);
 
     this.handleDateWorkedChange = this.handleDateWorkedChange.bind(this);
-    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(
-      this
-    );
+    this.getDateWorkedValidationState = this.getDateWorkedValidationState.bind(this);
 
     this.handleHoursWorkedChange = this.handleHoursWorkedChange.bind(this);
-    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(
-      this
-    );
+    this.getHoursWorkedValidationState = this.getHoursWorkedValidationState.bind(this);
 
     this.validateAll = this.validateAll.bind(this);
 
@@ -96,20 +92,13 @@ class TimeunitForm extends Component {
   }
 
   validateAll() {
-    return (
-      this.state.project.value &&
-      this.state.dateWorked.value &&
-      this.state.hoursWorked.value
-    );
+    return this.state.project.value && this.state.dateWorked.value && this.state.hoursWorked.value;
   }
 
   render() {
     return (
       <form>
-        <FormGroup
-          controlId="project"
-          validationState={this.getProjectValidationState()}
-        >
+        <FormGroup controlId="project" validationState={this.getProjectValidationState()}>
           <ControlLabel>Project</ControlLabel>
           <FormControl
             value={this.state.project.value}
@@ -126,10 +115,7 @@ class TimeunitForm extends Component {
           </FormControl>
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="dateWorked"
-          validationState={this.getDateWorkedValidationState()}
-        >
+        <FormGroup controlId="dateWorked" validationState={this.getDateWorkedValidationState()}>
           <ControlLabel>Date Worked</ControlLabel>
           <FormControl
             type="text"
@@ -139,10 +125,7 @@ class TimeunitForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <FormGroup
-          controlId="hoursWorked"
-          validationState={this.getHoursWorkedValidationState()}
-        >
+        <FormGroup controlId="hoursWorked" validationState={this.getHoursWorkedValidationState()}>
           <ControlLabel>Hours Worked</ControlLabel>
           <FormControl
             type="text"
@@ -152,21 +135,12 @@ class TimeunitForm extends Component {
           />
           <FormControl.Feedback />
         </FormGroup>
-        <Button
-          bsStyle="success"
-          onClick={this.handleSave}
-          disabled={!this.validateAll()}
-        >
+        <Button bsStyle="success" onClick={this.handleSave} disabled={!this.validateAll()}>
           {' '}
           Save{' '}
         </Button>&nbsp;
         <LinkContainer
-          to={
-            '/employees/' +
-            this.props.userId +
-            '/timesheets/detail/' +
-            this.props.timesheetId
-          }
+          to={'/employees/' + this.props.userId + '/timesheets/detail/' + this.props.timesheetId}
         >
           <Button bsStyle="danger"> Cancel </Button>
         </LinkContainer>

--- a/lab-05-form-validation/src/components/timeunits/TimeunitRow.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitRow.js
@@ -1,51 +1,65 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import {Button} from 'react-bootstrap';
+import { Button } from 'react-bootstrap';
 import { withRouter } from 'react-router';
 
 class TimeunitRow extends Component {
-
   handleClick(timesheet, timeunit) {
-    if(timeunit.deleted){
+    if (timeunit.deleted) {
       timeunit.deleted = false;
-      this.props.actions.restoreTimeunit(timesheet._id, timeunit).then(()=>{
+      this.props.actions.restoreTimeunit(timesheet._id, timeunit).then(() => {
         this.props.actions.listTimeunits(timesheet._id);
       });
-    }
-    else{
+    } else {
       timeunit.deleted = true;
-      this.props.actions.removeTimeunit(timesheet._id, timeunit).then(()=>{
+      this.props.actions.removeTimeunit(timesheet._id, timeunit).then(() => {
         this.props.actions.listTimeunits(timesheet._id);
       });
     }
   }
 
   showDetail(timesheet, timeunit) {
-    if(timeunit.deleted) {
+    if (timeunit.deleted) {
       console.log('You cannot edit a deleted timeunit.');
       return;
     }
 
-    this.props.history.push('/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id + '/timeunits/detail/' + timeunit._id);
+    this.props.history.push(
+      '/employees/' +
+        timesheet.user_id +
+        '/timesheets/detail/' +
+        timesheet._id +
+        '/timeunits/detail/' +
+        timeunit._id
+    );
   }
 
   render() {
-    let rowClass = "";
-    if(this.props.timeunit.deleted){
-      rowClass = "faded";
+    let rowClass = '';
+    if (this.props.timeunit.deleted) {
+      rowClass = 'faded';
     }
 
     const button = (
       <Button
-        onClick={(e) => {this.handleClick(this.props.timesheet, this.props.timeunit); e.stopPropagation();}}
+        onClick={e => {
+          this.handleClick(this.props.timesheet, this.props.timeunit);
+          e.stopPropagation();
+        }}
         bsStyle={this.props.timeunit.deleted ? 'success' : 'danger'}
       >
         {this.props.timeunit.deleted ? 'Restore' : 'Delete'}
-      </Button>);
+      </Button>
+    );
 
     return (
-      <tr className={rowClass} onClick={() => {this.showDetail(this.props.timesheet, this.props.timeunit)}}>
+      <tr
+        className={rowClass}
+        onClick={() => {
+          this.showDetail(this.props.timesheet, this.props.timeunit);
+        }}
+      >
         <td>{this.props.timeunit.project}</td>
         <td>{this.props.timeunit.dateWorked}</td>
         <td>{this.props.timeunit.hoursWorked}</td>

--- a/lab-05-form-validation/src/components/timeunits/TimeunitRow.test.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitRow.test.js
@@ -1,19 +1,21 @@
 import React from 'react';
 import TimeunitRow from './TimeunitRow';
-import {mount} from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timeunit Row Component: ', () =>  {
-
+describe('Timeunit Row Component: ', () => {
   let timesheetRow;
 
-  beforeEach(() =>{
+  beforeEach(() => {
     const timeunit = {};
-    timesheetRow = mount(<MemoryRouter><TimeunitRow timeunit={timeunit} /></MemoryRouter>);
+    timesheetRow = mount(
+      <MemoryRouter>
+        <TimeunitRow timeunit={timeunit} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the TimeunitRow Component', () =>  {
+  it('should instantiate the TimeunitRow Component', () => {
     expect(timesheetRow).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/timeunits/TimeunitTable.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitTable.js
@@ -2,34 +2,36 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimeunitRow from './TimeunitRow';
-import {Table} from 'react-bootstrap';
+import { Table } from 'react-bootstrap';
 
 class TimeunitTable extends Component {
   render() {
-
     const actions = this.props.actions;
 
     const timesheet = this.props.timesheet;
 
     let timeunitRows = this.props.timeunits.map(timeunit => {
       return (
-        <TimeunitRow timeunit={timeunit} timesheet={timesheet} key={timeunit._id} actions={actions}/>
+        <TimeunitRow
+          timeunit={timeunit}
+          timesheet={timesheet}
+          key={timeunit._id}
+          actions={actions}
+        />
       );
     });
 
     return (
       <Table striped bordered condensed hover>
         <thead>
-        <tr>
-          <th>Project</th>
-          <th>Date</th>
-          <th>Hours</th>
-          <th>Delete</th>
-        </tr>
+          <tr>
+            <th>Project</th>
+            <th>Date</th>
+            <th>Hours</th>
+            <th>Delete</th>
+          </tr>
         </thead>
-        <tbody>
-        {timeunitRows}
-        </tbody>
+        <tbody>{timeunitRows}</tbody>
       </Table>
     );
   }

--- a/lab-05-form-validation/src/components/timeunits/TimeunitTable.test.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitTable.test.js
@@ -1,19 +1,21 @@
 import React from 'react';
 import TimeunitTable from './TimeunitTable';
-import {mount} from 'enzyme';
-import {MemoryRouter} from 'react-router-dom';
+import { mount } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timeunit Table Component: ', () =>  {
-
+describe('Timeunit Table Component: ', () => {
   let timeunitTable;
 
-  beforeEach(() =>{
-    const timeunits = [{_id: 1}, {_id: 2}];
-    timeunitTable = mount(<MemoryRouter><TimeunitTable timeunits={timeunits} /></MemoryRouter>);
+  beforeEach(() => {
+    const timeunits = [{ _id: 1 }, { _id: 2 }];
+    timeunitTable = mount(
+      <MemoryRouter>
+        <TimeunitTable timeunits={timeunits} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timeunit Component', () =>  {
+  it('should instantiate the Timeunit Component', () => {
     expect(timeunitTable).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/timeunits/Timeunits.js
+++ b/lab-05-form-validation/src/components/timeunits/Timeunits.js
@@ -1,13 +1,12 @@
 import React, { Component } from 'react';
 import TimeunitTable from './TimeunitTable';
-import {PageHeader, Grid, Row, Button} from 'react-bootstrap';
-import {LinkContainer} from 'react-router-bootstrap';
+import { PageHeader, Grid, Row, Button } from 'react-bootstrap';
+import { LinkContainer } from 'react-router-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimeunitActions from '../../actions/TimeunitActionCreator';
 
 class Timeunits extends Component {
-
   constructor(props) {
     super(props);
 
@@ -16,7 +15,9 @@ class Timeunits extends Component {
 
   render() {
     const timesheet = this.props.timesheet;
-    const timeunitsCreateLink = timesheet ? `/employees/${timesheet.user_id}/timesheets/detail/${timesheet._id}/timeunits/create` : '';
+    const timeunitsCreateLink = timesheet
+      ? `/employees/${timesheet.user_id}/timesheets/detail/${timesheet._id}/timeunits/create`
+      : '';
     return (
       <Grid>
         <Row>
@@ -30,27 +31,27 @@ class Timeunits extends Component {
           </div>
         </Row>
         <Row>
-          <TimeunitTable timeunits={this.props.timeunits} timesheet={this.props.timesheet} actions={this.props.actions}/>
+          <TimeunitTable
+            timeunits={this.props.timeunits}
+            timesheet={this.props.timesheet}
+            actions={this.props.actions}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timeunits: state.timeunits.timeunits
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimeunitActions, dispatch)
   };
-}
+};
 
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Timeunits);
+export default connect(mapStateToProps, mapDispatchToProps)(Timeunits);

--- a/lab-05-form-validation/src/components/timeunits/Timeunits.test.js
+++ b/lab-05-form-validation/src/components/timeunits/Timeunits.test.js
@@ -1,22 +1,24 @@
 import React from 'react';
 import Timeunits from './Timeunits';
-import {mount} from 'enzyme';
+import { mount } from 'enzyme';
 import configureStore from '../../store/configure-store';
-import {MemoryRouter} from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 
-describe('Timeunits Component: ', () =>  {
-
+describe('Timeunits Component: ', () => {
   let timeunits;
   let timesheet;
   const mockStore = configureStore();
 
-  beforeEach(() =>{
-    timesheet = {_id: '123'}
-    timeunits = mount(<MemoryRouter><Timeunits store={mockStore} timesheet={timesheet}/></MemoryRouter>);
+  beforeEach(() => {
+    timesheet = { _id: '123' };
+    timeunits = mount(
+      <MemoryRouter>
+        <Timeunits store={mockStore} timesheet={timesheet} />
+      </MemoryRouter>
+    );
   });
 
-  it('should instantiate the Timeunit Component', () =>  {
+  it('should instantiate the Timeunit Component', () => {
     expect(timeunits).toHaveLength(1);
   });
-
 });

--- a/lab-05-form-validation/src/components/timeunits/TimeunitsCreate.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitsCreate.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import TimeunitForm from './TimeunitForm';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimeunitActions from '../../actions/TimeunitActionCreator';
@@ -10,22 +10,25 @@ import * as ProjectActions from '../../actions/ProjectActionCreator';
 import { withRouter } from 'react-router';
 
 class TimeunitsCreate extends Component {
-
   constructor(props) {
     super(props);
     this.props.projectActions.listProjects();
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(timeunit){
+  handleSave(timeunit) {
     const timesheet = this.props.timesheet;
     this.props.actions.createTimeunit(timesheet._id, timeunit).then(() => {
-
       //Reload all of the timeunits after the save
       this.props.actions.listTimeunits(timesheet._id);
 
       //Redirect back to the detail page to see all time entries
-      this.props.history.push('/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id);
+      this.props.history.push(
+        '/employees/' +
+          timesheet.user_id +
+          '/timesheets/detail/' +
+          timesheet._id
+      );
     });
   }
 
@@ -36,9 +39,14 @@ class TimeunitsCreate extends Component {
           <PageHeader>Timeunits Create</PageHeader>
         </Row>
         <Row>
-          <TimeunitForm timesheetId={this.props.timesheet._id} userId={this.props.timesheet.user_id}
-                        timeunit={this.props.timeunit} actions={this.props.actions} handleSave={this.handleSave}
-                        projects={this.props.projects}/>
+          <TimeunitForm
+            timesheetId={this.props.timesheet._id}
+            userId={this.props.timesheet.user_id}
+            timeunit={this.props.timeunit}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+            projects={this.props.projects}
+          />
         </Row>
       </Grid>
     );
@@ -56,22 +64,20 @@ TimeunitsCreate.defaultProps = {
   projects: []
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timesheet: state.timesheets.timesheet,
     projects: state.projects.projects
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimeunitActions, dispatch),
     projectActions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimeunitsCreate));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimeunitsCreate)
+);

--- a/lab-05-form-validation/src/components/timeunits/TimeunitsCreate.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitsCreate.js
@@ -24,10 +24,7 @@ class TimeunitsCreate extends Component {
 
       //Redirect back to the detail page to see all time entries
       this.props.history.push(
-        '/employees/' +
-          timesheet.user_id +
-          '/timesheets/detail/' +
-          timesheet._id
+        '/employees/' + timesheet.user_id + '/timesheets/detail/' + timesheet._id
       );
     });
   }
@@ -78,6 +75,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimeunitsCreate)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimeunitsCreate));

--- a/lab-05-form-validation/src/components/timeunits/TimeunitsDetail.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitsDetail.js
@@ -26,9 +26,7 @@ class TimeunitsDetail extends Component {
       //Reload all of the timeunits after the save
       this.props.actions.listTimeunits(timesheetId);
 
-      this.props.history.push(
-        `/employees/${userId}/timesheets/detail/${timesheetId}`
-      );
+      this.props.history.push(`/employees/${userId}/timesheets/detail/${timesheetId}`);
     });
   }
 
@@ -69,6 +67,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(TimeunitsDetail)
-);
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(TimeunitsDetail));

--- a/lab-05-form-validation/src/components/timeunits/TimeunitsDetail.js
+++ b/lab-05-form-validation/src/components/timeunits/TimeunitsDetail.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { withRouter } from 'react-router';
-import {PageHeader, Grid, Row} from 'react-bootstrap';
+import { PageHeader, Grid, Row } from 'react-bootstrap';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import * as TimeunitActions from '../../actions/TimeunitActionCreator';
@@ -8,7 +8,6 @@ import TimeunitForm from './TimeunitForm';
 import * as ProjectActions from '../../actions/ProjectActionCreator';
 
 class TimeunitsDetail extends Component {
-
   constructor(props) {
     super(props);
 
@@ -20,15 +19,16 @@ class TimeunitsDetail extends Component {
     this.handleSave = this.handleSave.bind(this);
   }
 
-  handleSave(timeunit){
+  handleSave(timeunit) {
     const userId = this.props.match.params.user_id;
     const timesheetId = this.props.match.params.timesheet_id;
     this.props.actions.updateTimeunit(timesheetId, timeunit).then(() => {
-
       //Reload all of the timeunits after the save
       this.props.actions.listTimeunits(timesheetId);
 
-      this.props.history.push(`/employees/${userId}/timesheets/detail/${timesheetId}`);
+      this.props.history.push(
+        `/employees/${userId}/timesheets/detail/${timesheetId}`
+      );
     });
   }
 
@@ -41,29 +41,34 @@ class TimeunitsDetail extends Component {
           <PageHeader>Timeunit Edit</PageHeader>
         </Row>
         <Row>
-          <TimeunitForm projects={this.props.projects} timesheetId={timesheetId} userId={userId} timeunit={this.props.timeunit} actions={this.props.actions} handleSave={this.handleSave}/>
+          <TimeunitForm
+            projects={this.props.projects}
+            timesheetId={timesheetId}
+            userId={userId}
+            timeunit={this.props.timeunit}
+            actions={this.props.actions}
+            handleSave={this.handleSave}
+          />
         </Row>
       </Grid>
     );
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     timeunit: state.timeunits.timeunit,
     projects: state.projects.projects
-  }
-}
+  };
+};
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     actions: bindActionCreators(TimeunitActions, dispatch),
     projectActions: bindActionCreators(ProjectActions, dispatch)
   };
-}
+};
 
-
-export default withRouter(connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(TimeunitsDetail));
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(TimeunitsDetail)
+);

--- a/lab-05-form-validation/src/hello/Hello.js
+++ b/lab-05-form-validation/src/hello/Hello.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 
 class Hello extends Component {
-
   constructor(props) {
     super(props);
     this.state = {
@@ -14,7 +13,7 @@ class Hello extends Component {
       <div className="hello">
         <h1>{this.state.greeting}</h1>
         <h2>{this.props.friend}</h2>
-        <p>Congratulations!  You have created your first React component!</p>
+        <p>Congratulations! You have created your first React component!</p>
       </div>
     );
   }

--- a/lab-05-form-validation/src/hello/Hello.test.js
+++ b/lab-05-form-validation/src/hello/Hello.test.js
@@ -4,13 +4,12 @@ import renderer from 'react-test-renderer';
 
 import Hello from './Hello';
 
-describe('Hello World:', () =>  {
-
+describe('Hello World:', () => {
   it('renders without exploding', () => {
     expect(shallow(<Hello />)).toHaveLength(1);
   });
 
-  it('should render with default text', () =>  {
+  it('should render with default text', () => {
     const component = shallow(<Hello />);
 
     expect(component).toIncludeText('Howdy');
@@ -19,10 +18,8 @@ describe('Hello World:', () =>  {
     expect(component).toHaveState('greeting', 'Howdy!!');
   });
 
-  it('should render with our props', () =>  {
-    const component = shallow(
-      <Hello friend="Fred"/>
-    );
+  it('should render with our props', () => {
+    const component = shallow(<Hello friend="Fred" />);
 
     expect(component).toIncludeText('Howdy');
 
@@ -30,12 +27,9 @@ describe('Hello World:', () =>  {
     expect(component).not.toIncludeText('Partner');
   });
 
-  it('should render to match the snapshot', () =>  {
-    const component = renderer.create(
-      <Hello friend="Luke"/>
-    );
+  it('should render to match the snapshot', () => {
+    const component = renderer.create(<Hello friend="Luke" />);
 
     expect(component.toJSON()).toMatchSnapshot();
   });
-
 });

--- a/lab-05-form-validation/src/reducers/employee-reducer.js
+++ b/lab-05-form-validation/src/reducers/employee-reducer.js
@@ -1,13 +1,13 @@
 import * as EmployeeActionTypes from '../actions/EmployeeActionTypes';
 
-export default (state = {employees: [], employee: {}}, action) => {
+export default (state = { employees: [], employee: {} }, action) => {
   switch (action.type) {
     case EmployeeActionTypes.LIST:
-      return Object.assign({}, state, {employees: action.employees});
+      return Object.assign({}, state, { employees: action.employees });
     case EmployeeActionTypes.GET:
-      return Object.assign({}, state, {employee: action.employee});
+      return Object.assign({}, state, { employee: action.employee });
 
     default:
       return state;
   }
-}
+};

--- a/lab-05-form-validation/src/reducers/index.js
+++ b/lab-05-form-validation/src/reducers/index.js
@@ -1,4 +1,4 @@
-import {combineReducers} from "redux";
+import { combineReducers } from 'redux';
 import projects from './project-reducer';
 import timesheets from './timesheet-reducer';
 import employees from './employee-reducer';

--- a/lab-05-form-validation/src/reducers/project-reducer.js
+++ b/lab-05-form-validation/src/reducers/project-reducer.js
@@ -1,13 +1,13 @@
 import * as ProjectActionTypes from '../actions/ProjectActionTypes';
 
-export default (state = {projects: [], project: {}}, action) => {
+export default (state = { projects: [], project: {} }, action) => {
   switch (action.type) {
     case ProjectActionTypes.LIST:
-      return Object.assign({}, state, {projects: action.projects});
+      return Object.assign({}, state, { projects: action.projects });
     case ProjectActionTypes.GET:
-      return Object.assign({}, state, {project: action.project});
+      return Object.assign({}, state, { project: action.project });
 
     default:
       return state;
   }
-}
+};

--- a/lab-05-form-validation/src/reducers/timesheet-reducer.js
+++ b/lab-05-form-validation/src/reducers/timesheet-reducer.js
@@ -1,15 +1,15 @@
 import * as TimesheetActionTypes from '../actions/TimesheetActionTypes';
 import * as EmployeeActionTypes from '../actions/EmployeeActionTypes';
 
-export default (state = {timesheets: [], timesheet: {}}, action) => {
+export default (state = { timesheets: [], timesheet: {} }, action) => {
   switch (action.type) {
     case TimesheetActionTypes.LIST:
-      return Object.assign({}, state, {timesheets: action.timesheets});
+      return Object.assign({}, state, { timesheets: action.timesheets });
     case TimesheetActionTypes.GET:
-      return Object.assign({}, state, {timesheet: action.timesheet});
+      return Object.assign({}, state, { timesheet: action.timesheet });
     case EmployeeActionTypes.LIST:
-      return Object.assign({}, state, {employees: action.employees});
+      return Object.assign({}, state, { employees: action.employees });
     default:
       return state;
   }
-}
+};

--- a/lab-05-form-validation/src/reducers/timeunit-reducer.js
+++ b/lab-05-form-validation/src/reducers/timeunit-reducer.js
@@ -1,16 +1,16 @@
 import * as TimeunitActionTypes from '../actions/TimeunitActionTypes';
 import * as ProjectActionTypes from '../actions/ProjectActionTypes';
 
-export default (state = {timeunits: [], timeunit: {}}, action) => {
+export default (state = { timeunits: [], timeunit: {} }, action) => {
   switch (action.type) {
     case TimeunitActionTypes.LIST:
-      return Object.assign({}, state, {timeunits: action.timeunits});
+      return Object.assign({}, state, { timeunits: action.timeunits });
     case TimeunitActionTypes.GET:
-      return Object.assign({}, state, {timeunit: action.timeunit});
+      return Object.assign({}, state, { timeunit: action.timeunit });
     case ProjectActionTypes.LIST:
-      return Object.assign({}, state, {projects: action.projects});
+      return Object.assign({}, state, { projects: action.projects });
 
     default:
       return state;
   }
-}
+};

--- a/lab-05-form-validation/src/setupTests.js
+++ b/lab-05-form-validation/src/setupTests.js
@@ -2,9 +2,9 @@
 //See: https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/template/README.md#initializing-test-environment
 
 import 'jest-enzyme';
-import { configure } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-16'
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 configure({
   adapter: new Adapter()
-})
+});

--- a/lab-05-form-validation/src/store/configure-store.js
+++ b/lab-05-form-validation/src/store/configure-store.js
@@ -1,9 +1,7 @@
 import rootReducer from '../reducers';
-import {createStore, applyMiddleware} from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
-export default (initialState = {projects: []}) => {
-  return createStore(rootReducer, initialState,
-    applyMiddleware(thunk)
-  );
+export default (initialState = { projects: [] }) => {
+  return createStore(rootReducer, initialState, applyMiddleware(thunk));
 };


### PR DESCRIPTION
This PR--which does not necessarily need to be merged--runs prettier on the code base so we can unify code style.

This also fixes some issues where we were directly mutating state (i.e. `this.state =`) instead of `this.setState()` like [here](https://github.com/objectpartners/react-redux-timesheet/blob/master/final/src/components/employees/EmployeeForm.js#L42)